### PR TITLE
Align roadmap with accelerated launch timeline

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,0 +1,56 @@
+# Triumph BRM Companion App – High-Level Development Roadmap
+
+This roadmap outlines the major engineering stages required to deliver the Triumph BRM Companion App. Each phase highlights the focus areas and key outputs that guide coding and product development, keeping attention on building the core platform, model intelligence, and automation capabilities that underpin the client experience while targeting a complete launch in under two weeks.
+
+## Phase 0 – Foundation Alignment
+**Focus**: Establish shared understanding, architecture guardrails, and delivery infrastructure before feature work begins.
+- Capture technical requirements around industry intelligence, Hormozi model alignment, and orchestration outcomes.
+- Define domain models, platform boundaries, and initial Supabase schema to ground the codebase structure.
+- Stand up repositories, environments, and CI/CD pipelines to support iterative implementation.
+
+## Phase 1 – Core Platform Enablement
+**Focus**: Deliver the authenticated client and coach experiences along with the foundational BRM level services.
+- Implement role-aware portals and shared component library across web and mobile surfaces.
+- Encode Hormozi model level primitives (Attraction, Upsell, Downsell, Continuity) with gating logic and data validation.
+- Harden platform operations with observability, automated testing baselines, and secure data access patterns.
+
+## Phase 2 – Industry Intelligence & Recommendation Layer
+**Focus**: Build the capabilities that let the system understand each client’s business and propose the appropriate Hormozi-aligned model types.
+- Deliver ingestion pathways for qualitative and quantitative industry signals with a reusable data model.
+- Develop the recommendation service that fuses heuristic scoring and AI prompting while maintaining explainability.
+- Surface recommendations within the product with override controls, audit trails, and monitoring of accuracy.
+
+## Phase 3 – Coach Collaboration & Approval Workspace
+**Focus**: Empower coaches to refine suggested models and formally approve the configurations that drive downstream automation.
+- Provide shared editing, versioning, and commenting tools on top of the recommendation payloads.
+- Manage approval lifecycles with notifications, explicit checkpoints, and immutable records of the final model blueprint.
+- Extend mobile and web experiences to support real-time collaboration and approvals on the go.
+
+## Phase 4 – Automated Journey Orchestration
+**Focus**: Translate approved models into executable customer journeys, backend structures, and operational workflows.
+- Define automation blueprints that map model components to assets, integrations, and metrics.
+- Implement the orchestration engine with safety mechanisms, preview modes, and integration adapters.
+- Visualize generated journeys and provide fulfillment playbooks that connect to the broader Triumph ecosystem.
+
+## Phase 5 – Optimization & Scale
+**Focus**: Enhance intelligence, monetize continuity tiers, and prepare the platform for broad client adoption.
+- Introduce predictive insights, closed-loop learning, and advanced KPI instrumentation.
+- Launch continuity billing, entitlement management, and self-service controls for mature clients.
+- Complete compliance, performance, and resilience hardening based on pilot feedback and telemetry.
+
+## Cross-Cutting Engineering Themes
+- **AI Safety & Governance**: Guardrails, evaluation frameworks, and documentation that keep recommendations reliable.
+- **Data Stewardship**: Privacy-aware data modeling, retention plans, and backup strategies spanning all phases.
+- **Developer Experience**: Shared tooling, reusable libraries, and test automation that sustain delivery velocity.
+- **Release & Support Readiness**: Feature flagging, staged rollouts, observability, and runbooks for ongoing operations.
+
+## Rollout Considerations
+- Internal alpha following Phase 2 to validate recommendation fidelity with Triumph coaches.
+- Pilot beta after Phase 3 to exercise collaboration tooling and dry-run automation in a sandbox.
+- Production launch on completion of Phase 4 with guardrails and progressive enablement of automation features.
+- Expansion in Phase 5 with continuity offerings, enhanced insights, and quarterly roadmap recalibration.
+
+## Near-Term Next Steps
+- Confirm architecture decisions, resource allocations, and sprint cadence for Phase 0.
+- Schedule discovery and data taxonomy sessions with Triumph coaches and SMEs.
+- Stand up baseline repositories, environments, and CI automations to support ongoing development.


### PR DESCRIPTION
## Summary
- remove the week-by-week duration callouts across the roadmap phases
- highlight the accelerated sub-two-week launch goal in the roadmap introduction

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e131fe7948832c9e720a137fa1cad5