### PR TITLE
Fix Supabase imports for coach dashboard

### DIFF
--- a/app/coach/components/KpiInlineEditor.tsx
+++ b/app/coach/components/KpiInlineEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "../../../lib/supabase";
+import { getSupabaseBrowserClient } from "../../../lib/supabase";
 
 type Props = {
   kpiId: string;
@@ -27,6 +27,13 @@ export default function KpiInlineEditor({
   }, [value]);
 
   const handleSave = async () => {
+    const supabase = getSupabaseBrowserClient();
+
+    if (!supabase) {
+      onNotify("error", "Supabase is not configured.");
+      return;
+    }
+
     const trimmed = inputValue.trim();
     const parsedValue = trimmed === "" ? null : Number(trimmed);
 
@@ -45,7 +52,10 @@ export default function KpiInlineEditor({
     try {
       const { error: updateError } = await supabase
         .from("kpis")
-        .update({ value: parsedValue })
+        .update(
+          // The generated Supabase types are placeholders at the moment, so cast to satisfy TS.
+          { value: parsedValue } as never,
+        )
         .eq("id", kpiId);
 
       if (updateError) {

--- a/app/coach/page.tsx
+++ b/app/coach/page.tsx
@@ -1,5 +1,5 @@
 import ClientGrid, { ClientWithRelations } from "./components/ClientCard";
-import { supabase } from "../../lib/supabase";
+import { getServerClient } from "../../lib/supabase-server";
 
 type ClientRow = {
   id: string;
@@ -34,6 +34,8 @@ type KpiRow = {
 export const dynamic = "force-dynamic";
 
 async function fetchClientsData() {
+  const supabase = getServerClient();
+
   const [clientsRes, modelsRes, milestonesRes, kpisRes] = await Promise.all([
     supabase.from("clients").select("id, name"),
     supabase.from("models").select("id, client_id, level, status, created_at"),

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -8,7 +8,14 @@ export type Json =
 
 export type Database = {
   public: {
-    Tables: Record<string, never>;
+    Tables: Record<
+      string,
+      {
+        Row: Record<string, unknown>;
+        Insert: Record<string, unknown>;
+        Update: Record<string, unknown>;
+      }
+    >;
     Views: Record<string, never>;
     Functions: Record<string, never>;
     Enums: Record<string, never>;


### PR DESCRIPTION
## Summary
- replace outdated Supabase imports in coach components with the shared browser/server helpers
- ensure the coach page obtains a server-side Supabase client before requesting data
- loosen placeholder Supabase database types so type-checking passes with the generic client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e299d86b80832cb913652ecf6f6056