### PR TITLE
Fix missing Supabase client export

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,12 +2,9 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../types/supabase";
 
 let browserClient: SupabaseClient<Database> | null = null;
+let serverClient: SupabaseClient<Database> | null = null;
 
-export function getSupabaseBrowserClient(): SupabaseClient<Database> | null {
-  if (browserClient) {
-    return browserClient;
-  }
-
+function getSupabaseEnv() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -15,7 +12,46 @@ export function getSupabaseBrowserClient(): SupabaseClient<Database> | null {
     return null;
   }
 
-  browserClient = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  return { supabaseUrl, supabaseAnonKey };
+}
+
+export function getSupabaseClient(): SupabaseClient<Database> | null {
+  if (typeof window !== "undefined") {
+    return getSupabaseBrowserClient();
+  }
+
+  if (serverClient) {
+    return serverClient;
+  }
+
+  const env = getSupabaseEnv();
+
+  if (!env) {
+    return null;
+  }
+
+  serverClient = createClient<Database>(env.supabaseUrl, env.supabaseAnonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  return serverClient;
+}
+
+export function getSupabaseBrowserClient(): SupabaseClient<Database> | null {
+  if (browserClient) {
+    return browserClient;
+  }
+
+  const env = getSupabaseEnv();
+
+  if (!env) {
+    return null;
+  }
+
+  browserClient = createClient<Database>(env.supabaseUrl, env.supabaseAnonKey, {
     auth: {
       persistSession: true,
       autoRefreshToken: true,
@@ -26,7 +62,5 @@ export function getSupabaseBrowserClient(): SupabaseClient<Database> | null {
 }
 
 export function isSupabaseConfigured(): boolean {
-  return Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  );
+  return Boolean(getSupabaseEnv());
 }


### PR DESCRIPTION
## Summary
- add a shared Supabase client helper that supports both server and browser environments
- reuse shared environment parsing across helpers and tighten configuration checks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a0a94ee0832cb397049da404e186