### PR TITLE
Add forgot password option to login screen

### DIFF
--- a/app/login/login.css
+++ b/app/login/login.css
@@ -369,6 +369,30 @@
   color: rgba(233, 238, 255, 0.4);
 }
 
+.form-secondary-link {
+  justify-self: start;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  cursor: pointer;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.form-secondary-link:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.form-secondary-link:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
 .primary-button {
   border: none;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- add a secondary action on the login form so users can request a password reset email
- call Supabase resetPasswordForEmail when configured and provide mock logging otherwise
- style the new action to match the existing login scene visuals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e2b09e1014832c901668c964cbde8f