### PR TITLE
Implement role-based Supabase login redirects

### DIFF
--- a/hooks/useRoleRedirect.ts
+++ b/hooks/useRoleRedirect.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+
+import { PENDING_APPROVAL_ROUTE, resolveRoleRedirect } from "@/lib/auth";
+import type { Database } from "@/types/supabase";
+
+type UseRoleRedirectOptions = {
+  supabase: SupabaseClient<Database> | null;
+  enabled?: boolean;
+  onRedirectStart?: () => void;
+  onRedirectEnd?: () => void;
+};
+
+type HandleRoleRedirect = (session: Session | null, reason?: string) => Promise<void>;
+
+export const useRoleRedirect = ({
+  supabase,
+  enabled = true,
+  onRedirectStart,
+  onRedirectEnd,
+}: UseRoleRedirectOptions) => {
+  const router = useRouter();
+  const [isCheckingRole, setIsCheckingRole] = useState(false);
+
+  const handleRoleRedirect = useCallback<HandleRoleRedirect>(
+    async (session, reason) => {
+      if (!enabled || !session || !supabase) {
+        return;
+      }
+
+      setIsCheckingRole(true);
+      onRedirectStart?.();
+
+      try {
+        const { destination, role } = await resolveRoleRedirect(supabase, session);
+        console.log(
+          `[useRoleRedirect] Redirecting user ${session.user.id} (${role ?? "unknown"}) to ${destination}${
+            reason ? ` [${reason}]` : ""
+          }`,
+        );
+        router.replace(destination);
+      } catch (error) {
+        console.error("[useRoleRedirect] Failed to resolve role-based redirect:", error);
+        router.replace(PENDING_APPROVAL_ROUTE);
+      } finally {
+        setIsCheckingRole(false);
+        onRedirectEnd?.();
+      }
+    },
+    [enabled, onRedirectEnd, onRedirectStart, router, supabase],
+  );
+
+  useEffect(() => {
+    if (!enabled || !supabase) {
+      return;
+    }
+
+    let isMounted = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!isMounted) {
+        return;
+      }
+
+      void handleRoleRedirect(data.session, "existing session");
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session) {
+        return;
+      }
+
+      void handleRoleRedirect(session, "auth state change");
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, [enabled, handleRoleRedirect, supabase]);
+
+  return {
+    handleRoleRedirect,
+    isCheckingRole,
+  };
+};

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,97 @@
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/types/supabase";
+
+export type SupportedUserRole = "mentor_admin" | "mentor" | "client";
+
+const ROLE_DESTINATION_MAP: Record<SupportedUserRole, string> = {
+  mentor_admin: "/mentor",
+  mentor: "/mentor",
+  client: "/client",
+};
+
+const PENDING_APPROVAL_ROUTE = "/pending-approval";
+
+type RoleResolutionResult = {
+  destination: string;
+  role: SupportedUserRole | null;
+};
+
+type Metadata = Record<string, unknown> | undefined;
+
+const normalizeRole = (role: unknown): SupportedUserRole | null => {
+  if (typeof role !== "string") {
+    return null;
+  }
+
+  const normalized = role.trim().toLowerCase();
+
+  if (normalized === "mentor_admin" || normalized === "mentor" || normalized === "client") {
+    return normalized as SupportedUserRole;
+  }
+
+  return null;
+};
+
+const resolveDestinationForRole = (role: SupportedUserRole | null): RoleResolutionResult => {
+  if (!role) {
+    return { destination: PENDING_APPROVAL_ROUTE, role: null };
+  }
+
+  const destination = ROLE_DESTINATION_MAP[role];
+
+  if (!destination) {
+    return { destination: PENDING_APPROVAL_ROUTE, role: null };
+  }
+
+  console.log(`[resolveRoleRedirect] Redirecting role "${role}" to "${destination}".`);
+
+  return { destination, role };
+};
+
+export const resolveRoleRedirect = async (
+  supabase: SupabaseClient<Database>,
+  session: Session,
+): Promise<RoleResolutionResult> => {
+  const appMetadataRole = normalizeRole((session.user.app_metadata as Metadata)?.role);
+  const userMetadataRole = normalizeRole((session.user.user_metadata as Metadata)?.role);
+  const metadataRole = appMetadataRole ?? userMetadataRole ?? null;
+
+  if (metadataRole) {
+    return resolveDestinationForRole(metadataRole);
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", session.user.id)
+      .maybeSingle<{ role: string | null }>();
+
+    if (error) {
+      console.error("[resolveRoleRedirect] Failed to fetch role from profiles table:", error);
+    }
+
+    const profileRole = normalizeRole(data?.role ?? null);
+
+    if (profileRole) {
+      return resolveDestinationForRole(profileRole);
+    }
+
+    if (data?.role) {
+      console.warn(
+        `[resolveRoleRedirect] Received unexpected role value "${data.role}" for user ${session.user.id}. Redirecting to pending approval.`,
+      );
+    }
+  } catch (error) {
+    console.error("[resolveRoleRedirect] Unexpected error while resolving role redirect:", error);
+  }
+
+  console.log(
+    `[resolveRoleRedirect] No role found for user ${session.user.id}. Redirecting to pending approval until access is confirmed.`,
+  );
+
+  return { destination: PENDING_APPROVAL_ROUTE, role: null };
+};
+
+export { PENDING_APPROVAL_ROUTE };


### PR DESCRIPTION
## Summary
- add reusable role resolution helpers that map Supabase roles to mentor, client, or pending approval dashboards
- introduce a client-side hook to fetch the authenticated role and drive redirects during login or session restoration
- update the login form to rely on the new hook, show a loading state during role checks, and invoke the redirect logic after sign-in

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b8d2fbf4832cb97ed8d4b3b19faa