### PR TITLE
Deepen dashboard overlay and elevate business profile card

### DIFF
--- a/app/dashboard/BusinessInformationModal.tsx
+++ b/app/dashboard/BusinessInformationModal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import BusinessInfoForm from "../../components/BusinessInfoForm";
+import { getSupabaseBrowserClient } from "../../lib/supabase";
+import type { Database } from "../../types/supabase";
+
+type BusinessInformationModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type BusinessContextRow = Database["public"]["Tables"]["business_context"]["Row"];
+type OfferStackRow = Database["public"]["Tables"]["offer_stack"]["Row"];
+type BrmLevel = Database["public"]["Enums"]["brm_level"];
+
+const BRM_LEVEL_FALLBACK: BrmLevel = "level_1";
+
+type FormSnapshot = {
+  brmLevel: BrmLevel;
+  initialContext: BusinessContextRow | null;
+  initialOffers: OfferStackRow[];
+};
+
+export default function BusinessInformationModal({ open, onClose }: BusinessInformationModalProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [snapshot, setSnapshot] = useState<FormSnapshot | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    if (!supabase) {
+      setLoadError("Supabase is not configured. Add your project keys to load the business information form.");
+      setSnapshot({
+        brmLevel: BRM_LEVEL_FALLBACK,
+        initialContext: null,
+        initialOffers: [],
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoading(true);
+    setLoadError(null);
+
+    async function loadBusinessInformation() {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (userError) {
+        setLoadError("We couldn’t verify your session. You can still review the form below.");
+        setSnapshot({
+          brmLevel: BRM_LEVEL_FALLBACK,
+          initialContext: null,
+          initialOffers: [],
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      if (!user) {
+        setLoadError("Sign in to save your business information.");
+        setSnapshot({
+          brmLevel: BRM_LEVEL_FALLBACK,
+          initialContext: null,
+          initialOffers: [],
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      const [contextResult, offerResult] = await Promise.all([
+        supabase
+          .from("business_context")
+          .select("*")
+          .eq("user_id", user.id)
+          .maybeSingle<BusinessContextRow>(),
+        supabase.from("offer_stack").select("*").eq("user_id", user.id).order("slot", { ascending: true }),
+      ]);
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (contextResult.error) {
+        setLoadError("We couldn’t load your saved context yet. You can still update the form below.");
+      } else if (offerResult.error) {
+        setLoadError("We couldn’t load your offer stack yet. You can still update the form below.");
+      } else {
+        setLoadError(null);
+      }
+
+      const metadataLevel =
+        ((user.user_metadata as { brm_level?: BrmLevel } | undefined)?.brm_level ??
+          (user.app_metadata as { brm_level?: BrmLevel } | undefined)?.brm_level ??
+          null) ?? BRM_LEVEL_FALLBACK;
+
+      const contextData = contextResult.data ?? null;
+      const offerData = offerResult.data ?? [];
+
+      const brmLevel = (contextData?.brm_level as BrmLevel | null) ?? metadataLevel;
+
+      setSnapshot({
+        brmLevel,
+        initialContext: contextData,
+        initialOffers: offerData,
+      });
+      setIsLoading(false);
+    }
+
+    void loadBusinessInformation();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [open, supabase, reloadToken]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleClose = () => {
+    setSnapshot(null);
+    setIsLoading(false);
+    setLoadError(null);
+    onClose();
+  };
+
+  const handleSuccess = () => {
+    handleClose();
+    setReloadToken((token) => token + 1);
+  };
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Business information form">
+      <div className="modal-card modal-card--form">
+        <button
+          type="button"
+          className="modal-close-button"
+          onClick={handleClose}
+          aria-label="Close business information form"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M4 4l10 10M14 4 4 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+        <div className="modal-form-wrapper">
+          {isLoading ? (
+            <p className="modal-status">Loading your saved details…</p>
+          ) : snapshot ? (
+            <>
+              {loadError ? <p className="modal-status error-text">{loadError}</p> : null}
+              <BusinessInfoForm
+                brmLevel={snapshot.brmLevel}
+                initialContext={snapshot.initialContext}
+                initialOffers={snapshot.initialOffers}
+                onSuccess={handleSuccess}
+              />
+            </>
+          ) : (
+            <p className="modal-status error-text">
+              {loadError ?? "We couldn’t load the business information form right now. Please try again later."}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+import BusinessInformationModal from "./BusinessInformationModal";
+
+export default function DashboardClient() {
+  const [isModalOpen, setModalOpen] = useState(true);
+
+  return (
+    <div className="dashboard-shell">
+      <div className="dashboard-inner">
+        <header className="dashboard-header">
+          <div className="dashboard-brand">
+            <span className="brand-glyph">TB</span>
+            <div className="brand-title">
+              <span>Triumph dashboard</span>
+              <span>Business Revenue Model</span>
+            </div>
+          </div>
+          <div className="header-actions">
+            <button className="settings-button" type="button" aria-label="Open settings menu">
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 22 22"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M5 7h12M5 11h12M5 15h12"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            <button className="primary-button" type="button" onClick={() => setModalOpen(true)}>
+              Update business info
+            </button>
+          </div>
+        </header>
+
+        <main className="dashboard-content">
+          <section className="hero-panel">
+            <div className="hero-copy">
+              <span className="hero-kicker">Client growth dashboard</span>
+              <h1 className="hero-title">Build momentum with clarity</h1>
+              <p className="hero-description">
+                Every session starts with the metrics that matter. Track revenue targets, highlight the offers propelling your
+                growth, and uncover the next best move for your team.
+              </p>
+              <div className="hero-actions">
+                <button className="primary-button" type="button" onClick={() => setModalOpen(true)}>
+                  Complete business snapshot
+                </button>
+                <button className="secondary-button" type="button">
+                  Explore roadmap
+                </button>
+              </div>
+            </div>
+            <div className="hero-metrics">
+              <div className="metric-card">
+                <span className="metric-label">Monthly revenue goal</span>
+                <span className="metric-value">$40k</span>
+                <span className="metric-caption">Keep the target visible to focus every sprint.</span>
+              </div>
+              <div className="metric-card">
+                <span className="metric-label">Active growth lever</span>
+                <span className="metric-value">Pipeline</span>
+                <span className="metric-caption">Double down on the channel bringing in ready buyers.</span>
+              </div>
+            </div>
+          </section>
+
+          <section className="dashboard-grid">
+            <article className="dashboard-card">
+              <h2 className="card-title">Weekly focus</h2>
+              <p className="card-description">
+                Align your mentor sessions around one growth lever. Capture the plays moving revenue, retention, and fulfillment
+                forward.
+              </p>
+              <p className="card-footnote">Updated every Monday</p>
+            </article>
+            <article className="dashboard-card">
+              <h2 className="card-title">Offer stack</h2>
+              <p className="card-description">
+                Map the signature offer plus ascension paths. Ensure pricing, promise, and delivery are dialed to your current
+                BRM level.
+              </p>
+              <p className="card-footnote">3 slots to refine</p>
+            </article>
+            <article className="dashboard-card">
+              <h2 className="card-title">Growth milestones</h2>
+              <p className="card-description">
+                Visualize the next checkpoints on your roadmap. Celebrate wins and unlock resources tailored to what’s next.
+              </p>
+              <p className="card-footnote">Automated from Supabase</p>
+            </article>
+          </section>
+
+          <section className="dashboard-updates">
+            <h2>What happens next</h2>
+            <ul className="update-list">
+              <li>Finalize your business profile so Triumph can personalize prompts and resources.</li>
+              <li>Invite your mentor to review this dashboard ahead of your next accountability call.</li>
+              <li>Drop upcoming launches, hiring milestones, or constraints in the notes section of the form.</li>
+            </ul>
+          </section>
+        </main>
+      </div>
+
+      <BusinessInformationModal open={isModalOpen} onClose={() => setModalOpen(false)} />
+    </div>
+  );
+}

--- a/app/dashboard/dashboard.css
+++ b/app/dashboard/dashboard.css
@@ -1,0 +1,422 @@
+.dashboard-shell {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(2rem, 4vw, 3.5rem);
+  background: radial-gradient(circle at top left, rgba(15, 23, 42, 0.6), transparent 55%),
+    radial-gradient(circle at 20% 80%, rgba(37, 99, 235, 0.22), transparent 60%),
+    linear-gradient(135deg, #0f172a, #111827 55%, #1e293b 100%);
+  color: #f8fafc;
+  font-family: "Rubik", "Segoe UI", sans-serif;
+  overflow: hidden;
+}
+
+.dashboard-shell::before {
+  content: "";
+  position: absolute;
+  inset: -25%;
+  background: radial-gradient(circle at 65% 18%, rgba(59, 130, 246, 0.45), transparent 45%),
+    radial-gradient(circle at 20% 40%, rgba(250, 204, 21, 0.36), transparent 45%),
+    radial-gradient(circle at 80% 75%, rgba(99, 102, 241, 0.32), transparent 50%);
+  filter: blur(90px);
+  opacity: 0.65;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.dashboard-shell::after {
+  content: "";
+  position: absolute;
+  inset: 12% 20% auto;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(148, 163, 184, 0.22), transparent 70%);
+  opacity: 0.4;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.dashboard-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.dashboard-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-glyph {
+  width: 44px;
+  height: 44px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+  box-shadow: 0 18px 45px rgba(251, 191, 36, 0.35);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: 0.08em;
+}
+
+.brand-title {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.brand-title span:first-child {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.brand-title span:last-child {
+  font-size: 1.5rem;
+  color: #f8fafc;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.settings-button {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  color: #e2e8f0;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+}
+
+.settings-button:hover,
+.settings-button:focus-visible {
+  transform: translateY(-1px) scale(1.03);
+  background: rgba(30, 41, 59, 0.9);
+  border-color: rgba(250, 204, 21, 0.45);
+  outline: none;
+}
+
+.primary-button {
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #f59e0b, #f97316);
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 18px 45px rgba(250, 204, 21, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 26px 60px rgba(250, 204, 21, 0.42);
+  outline: none;
+}
+
+.dashboard-content {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.65), rgba(2, 6, 23, 0.72));
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 32px;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  box-shadow: 0 30px 120px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(20px);
+}
+
+.hero-copy {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-kicker {
+  font-size: 0.8rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.hero-title {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  margin: 0;
+  color: #f8fafc;
+  letter-spacing: -0.01em;
+}
+
+.hero-description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.6;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.secondary-button {
+  padding: 0.6rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: #e2e8f0;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(250, 204, 21, 0.45);
+  outline: none;
+}
+
+.hero-metrics {
+  display: grid;
+  gap: 1rem;
+}
+
+.metric-card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.metric-caption {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.dashboard-card {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 16px 60px rgba(15, 23, 42, 0.45);
+}
+
+.dashboard-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(250, 204, 21, 0.08);
+  pointer-events: none;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #f8fafc;
+}
+
+.card-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.6;
+}
+
+.card-footnote {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-updates {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.5rem, 2.5vw, 2rem);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.dashboard-updates h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f8fafc;
+}
+
+.update-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.update-list li {
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .primary-button {
+    flex: 1;
+    text-align: center;
+  }
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 7, 18, 0.92);
+  backdrop-filter: blur(48px) saturate(180%);
+  -webkit-backdrop-filter: blur(48px) saturate(180%);
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  z-index: 20;
+  overflow-y: auto;
+  isolation: isolate;
+}
+
+.modal-overlay::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, rgba(59, 130, 246, 0.25), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(147, 197, 253, 0.18), transparent 55%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.92));
+  filter: blur(60px);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.modal-card {
+  position: relative;
+  width: min(960px, 100%);
+  max-height: none;
+  padding: clamp(1rem, 2.5vw, 2rem);
+  border-radius: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.modal-status {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.88);
+  text-align: center;
+}
+
+.error-text {
+  color: #fda4af;
+}
+
+.success-text {
+  color: #86efac;
+}
+
+.modal-card--form {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: clamp(0.5rem, 1.5vw, 1.25rem);
+}
+
+.modal-form-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.modal-form-wrapper > section {
+  margin: 0 auto;
+  width: 100%;
+}
+
+.modal-close-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.modal-close-button:hover,
+.modal-close-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(250, 204, 21, 0.55);
+  background: rgba(15, 23, 42, 0.85);
+  outline: none;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,23 +1,12 @@
 import type { Metadata } from "next";
 
-import "../login/login.css";
+import "./dashboard.css";
+import DashboardClient from "./DashboardClient";
 
 export const metadata: Metadata = {
   title: "Dashboard | Business Revenue Model App",
 };
 
 export default function DashboardPage() {
-  return (
-    <div className="login-scene" style={{ justifyContent: "center", alignItems: "center" }}>
-      <div className="login-particles" aria-hidden="true" />
-      <main className="login-stage" style={{ textAlign: "center", maxWidth: "640px" }}>
-        <div className="brand-header">
-          <h1 className="brand-title">Welcome aboard!</h1>
-          <p className="brand-description">
-            Thanks for signing up! Once your account is confirmed for access, you’ll be able to get started.
-          </p>
-        </div>
-      </main>
-    </div>
-  );
+  return <DashboardClient />;
 }

--- a/components/BusinessInfoForm.tsx
+++ b/components/BusinessInfoForm.tsx
@@ -13,6 +13,7 @@ type BusinessInfoFormProps = {
   brmLevel: Database["public"]["Enums"]["brm_level"];
   initialContext: BusinessContextRow | null;
   initialOffers: OfferStackRow[];
+  onSuccess?: () => void;
 };
 
 type OfferFormState = {
@@ -166,6 +167,12 @@ function toCurrencyPlaceholder(slot: number) {
   return "e.g. 497";
 }
 
+const offerTitleMap: Record<OfferFormState["slot"], string> = {
+  1: "Flagship offer",
+  2: "Signature companion",
+  3: "Entry pathway",
+};
+
 function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
 }
@@ -188,7 +195,14 @@ function parseNumberInput(value: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-export default function BusinessInfoForm({ brmLevel, initialContext, initialOffers }: BusinessInfoFormProps) {
+const baseControlClasses =
+  "w-full rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300/50 placeholder:text-slate-400";
+const errorControlClasses = "border-rose-400 focus:border-rose-400 focus:ring-rose-200/70";
+const fieldLabelClasses = "text-sm font-semibold text-slate-900";
+const fieldErrorClasses = "text-sm text-rose-500";
+const subheadingClasses = "text-sm font-medium uppercase tracking-[0.2em] text-indigo-500";
+
+export default function BusinessInfoForm({ brmLevel, initialContext, initialOffers, onSuccess }: BusinessInfoFormProps) {
   const router = useRouter();
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
@@ -324,132 +338,142 @@ export default function BusinessInfoForm({ brmLevel, initialContext, initialOffe
       return;
     }
 
-    router.push("/dashboard");
+    if (onSuccess) {
+      onSuccess();
+    } else {
+      router.push("/dashboard");
+    }
   };
 
   const corePromiseCharactersRemaining = Math.max(120 - corePromise.trim().length, 0);
 
   return (
-    <section className="mx-auto w-full max-w-5xl">
-      <div className="mb-10 flex flex-col gap-4 text-center">
-        <span className="mx-auto inline-flex items-center gap-2 rounded-full bg-indigo-100 px-4 py-1 text-sm font-medium text-indigo-700">
-          <span className="flex h-2 w-2 rounded-full bg-indigo-500" aria-hidden />
-          BRM Level: {brmLevelLabels[brmLevel]}
-          <span className="text-xs font-normal text-indigo-500">{brmLevelDescriptions[brmLevel]}</span>
-        </span>
-        <div className="space-y-3">
-          <h1 className="text-3xl font-semibold text-slate-900">Calibrate Your BRM Workspace</h1>
-          <p className="mx-auto max-w-2xl text-base text-slate-600">
-            This snapshot personalizes model ideas and checklists to your current level. Share how your business delivers results so your Mentor and Triumph resources stay tuned to your growth.
-          </p>
-        </div>
-      </div>
-
-      <form
-        onSubmit={handleSubmit}
-        className="space-y-10 rounded-3xl bg-white/90 p-8 shadow-xl ring-1 ring-slate-200 backdrop-blur"
-      >
-        <div className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-2xl border border-indigo-100 bg-indigo-50/70 p-6">
-            <h2 className="text-lg font-semibold text-indigo-900">Business snapshot</h2>
-            <p className="mt-1 text-sm text-indigo-700/80">
-              Anchor your Triumph workspace with how you serve clients today.
+    <section className="mx-auto w-full max-w-4xl">
+      <div className="relative overflow-hidden rounded-[40px] border border-slate-200/70 bg-white/98 px-6 py-10 shadow-[0_45px_120px_rgba(15,23,42,0.35)] backdrop-blur-xl sm:px-10 sm:py-12">
+        <div className="flex flex-col items-center gap-5 text-center">
+          <span className="inline-flex items-center gap-3 rounded-full border border-indigo-200/70 bg-white/95 px-5 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500 shadow-sm">
+            <span className="flex h-1.5 w-1.5 rounded-full bg-indigo-500" aria-hidden />
+            BRM LEVEL · {brmLevelLabels[brmLevel]} · {brmLevelDescriptions[brmLevel]}
+          </span>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Title:</p>
+            <h1 className="text-3xl font-semibold text-slate-900">Business Profile</h1>
+            <p className="text-base text-slate-600">
+              Please fill out this profile to allow the system to provide you with the most accurate plans, models, and more.
             </p>
-            <div className="mt-6 space-y-5">
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-indigo-900" htmlFor="offer_type">
-                  Type of business
-                </label>
-                <select
-                  id="offer_type"
-                  name="offer_type"
-                  className={classNames(
-                    "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                    fieldErrors["offer_type"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                  )}
-                  value={offerType}
-                  onChange={(event) => setOfferType(event.target.value as typeof offerType)}
-                  required
-                >
-                  <option value="" disabled>
-                    Select your business model
-                  </option>
-                  {offerTypes.map((value) => (
-                    <option key={value} value={value}>
-                      {formatEnumLabel(value)}
-                    </option>
-                  ))}
-                </select>
-                {fieldErrors["offer_type"] ? (
-                  <p className="text-sm text-rose-500">{fieldErrors["offer_type"]}</p>
-                ) : null}
-              </div>
+            <p className="text-sm text-slate-500">You can return and edit this profile at anytime in your profile settings.</p>
+          </div>
+        </div>
 
-              <div className="space-y-2">
-                <div className="flex items-center justify-between text-sm">
-                  <label className="font-medium text-indigo-900" htmlFor="core_promise">
-                    Core promise
+        <form onSubmit={handleSubmit} className="mt-10 space-y-12">
+            <section className="grid gap-8 lg:grid-cols-[minmax(0,2.1fr)_minmax(0,3fr)]">
+            <div className="rounded-[28px] border border-indigo-100/70 bg-gradient-to-br from-indigo-50 via-white to-indigo-100 p-8 shadow-inner">
+              <span className={subheadingClasses}>Business snapshot</span>
+              <h2 className="mt-3 text-2xl font-semibold text-slate-900">Anchor your current model</h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Capture the essentials of how you deliver and monetize today so Triumph can personalize dashboards, resources, and
+                Mentor recommendations.
+              </p>
+              <ul className="mt-6 space-y-2 text-left text-sm text-slate-600">
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-indigo-400" aria-hidden />
+                  Confirm your primary offer type and positioning.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-indigo-400" aria-hidden />
+                  Share the economics behind your flagship experiences.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-indigo-400" aria-hidden />
+                  Highlight the lead sources bringing buyers to you today.
+                </li>
+              </ul>
+            </div>
+
+            <div className="grid gap-6">
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="sm:col-span-2 space-y-2">
+                  <label className={fieldLabelClasses} htmlFor="offer_type">
+                    Type of business
                   </label>
-                  <span className="text-xs text-indigo-700/70">{corePromiseCharactersRemaining} characters left</span>
+                  <select
+                    id="offer_type"
+                    name="offer_type"
+                    className={classNames(baseControlClasses, fieldErrors["offer_type"] && errorControlClasses)}
+                    value={offerType}
+                    onChange={(event) => setOfferType(event.target.value as typeof offerType)}
+                    required
+                  >
+                    <option value="" disabled>
+                      Select your business model
+                    </option>
+                    {offerTypes.map((value) => (
+                      <option key={value} value={value}>
+                        {formatEnumLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                  {fieldErrors["offer_type"] ? <p className={fieldErrorClasses}>{fieldErrors["offer_type"]}</p> : null}
                 </div>
-                <input
-                  id="core_promise"
-                  name="core_promise"
-                  type="text"
-                  maxLength={120}
-                  placeholder="We help ___ achieve ___ in ___."
-                  className={classNames(
-                    "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                    fieldErrors["core_promise"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                  )}
-                  value={corePromise}
-                  onChange={(event) => setCorePromise(event.target.value)}
-                  required
-                />
-                {fieldErrors["core_promise"] ? (
-                  <p className="text-sm text-rose-500">{fieldErrors["core_promise"]}</p>
-                ) : null}
-              </div>
 
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-indigo-900" htmlFor="avg_txn_value">
-                  Average transaction value
-                </label>
-                <div className="relative">
-                  <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-slate-400">$
-                  </span>
+                <div className="sm:col-span-2 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className={fieldLabelClasses} htmlFor="core_promise">
+                      Core promise
+                    </label>
+                    <span className="text-xs font-medium text-indigo-500/80">
+                      {corePromiseCharactersRemaining} characters left
+                    </span>
+                  </div>
                   <input
-                    id="avg_txn_value"
-                    name="avg_txn_value"
-                    type="number"
-                    min={0}
-                    step="0.01"
-                    inputMode="decimal"
-                    className={classNames(
-                      "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 pl-7 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                      fieldErrors["avg_txn_value"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                    )}
-                    value={avgTransactionValue}
-                    onChange={(event) => setAvgTransactionValue(event.target.value)}
+                    id="core_promise"
+                    name="core_promise"
+                    type="text"
+                    maxLength={120}
+                    placeholder="We help ___ achieve ___ in ___."
+                    className={classNames(baseControlClasses, fieldErrors["core_promise"] && errorControlClasses)}
+                    value={corePromise}
+                    onChange={(event) => setCorePromise(event.target.value)}
+                    required
                   />
+                  {fieldErrors["core_promise"] ? <p className={fieldErrorClasses}>{fieldErrors["core_promise"]}</p> : null}
                 </div>
-                {fieldErrors["avg_txn_value"] ? (
-                  <p className="text-sm text-rose-500">{fieldErrors["avg_txn_value"]}</p>
-                ) : null}
-              </div>
 
-              <div className="grid gap-5 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-indigo-900" htmlFor="revenue_band">
+                  <label className={fieldLabelClasses} htmlFor="avg_txn_value">
+                    Average transaction value
+                  </label>
+                  <div className="relative">
+                    <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm font-semibold text-slate-400">
+                      $
+                    </span>
+                    <input
+                      id="avg_txn_value"
+                      name="avg_txn_value"
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      inputMode="decimal"
+                      className={classNames(
+                        baseControlClasses,
+                        "pl-8",
+                        fieldErrors["avg_txn_value"] && errorControlClasses,
+                      )}
+                      value={avgTransactionValue}
+                      onChange={(event) => setAvgTransactionValue(event.target.value)}
+                    />
+                  </div>
+                  {fieldErrors["avg_txn_value"] ? <p className={fieldErrorClasses}>{fieldErrors["avg_txn_value"]}</p> : null}
+                </div>
+
+                <div className="space-y-2">
+                  <label className={fieldLabelClasses} htmlFor="revenue_band">
                     Annual revenue band
                   </label>
                   <select
                     id="revenue_band"
                     name="revenue_band"
-                    className={classNames(
-                      "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                      fieldErrors["revenue_band"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                    )}
+                    className={classNames(baseControlClasses, fieldErrors["revenue_band"] && errorControlClasses)}
                     value={revenueBand}
                     onChange={(event) => setRevenueBand(event.target.value as typeof revenueBand)}
                     required
@@ -463,22 +487,17 @@ export default function BusinessInfoForm({ brmLevel, initialContext, initialOffe
                       </option>
                     ))}
                   </select>
-                  {fieldErrors["revenue_band"] ? (
-                    <p className="text-sm text-rose-500">{fieldErrors["revenue_band"]}</p>
-                  ) : null}
+                  {fieldErrors["revenue_band"] ? <p className={fieldErrorClasses}>{fieldErrors["revenue_band"]}</p> : null}
                 </div>
 
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-indigo-900" htmlFor="traffic_source">
+                  <label className={fieldLabelClasses} htmlFor="traffic_source">
                     Primary traffic source
                   </label>
                   <select
                     id="traffic_source"
                     name="traffic_source"
-                    className={classNames(
-                      "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                      fieldErrors["traffic_source"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                    )}
+                    className={classNames(baseControlClasses, fieldErrors["traffic_source"] && errorControlClasses)}
                     value={trafficSource ?? ""}
                     onChange={(event) => setTrafficSource(event.target.value as typeof trafficSource)}
                   >
@@ -489,38 +508,48 @@ export default function BusinessInfoForm({ brmLevel, initialContext, initialOffe
                       </option>
                     ))}
                   </select>
-                  {fieldErrors["traffic_source"] ? (
-                    <p className="text-sm text-rose-500">{fieldErrors["traffic_source"]}</p>
-                  ) : null}
+                  {fieldErrors["traffic_source"] ? <p className={fieldErrorClasses}>{fieldErrors["traffic_source"]}</p> : null}
                 </div>
               </div>
             </div>
-          </div>
+          </section>
 
-          <div className="rounded-2xl border border-purple-100 bg-gradient-to-br from-purple-50 via-white to-purple-100 p-6">
-            <h2 className="text-lg font-semibold text-purple-900">Top services & programs</h2>
-            <p className="mt-1 text-sm text-purple-800/80">
-              Capture the three offers you lead with most often. Each can be activated in future playbooks individually or together.
-            </p>
-            <div className="mt-6 space-y-6">
+          <section className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+            <div className="rounded-[28px] border border-purple-100/70 bg-gradient-to-br from-purple-50 via-white to-purple-100 p-8 shadow-inner">
+              <span className={classNames(subheadingClasses, "text-purple-500")}>Offers & delivery</span>
+              <h2 className="mt-3 text-2xl font-semibold text-slate-900">Showcase your lead offers</h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Listing your three most important offers helps us tailor conversion playbooks, fulfillment guidance, and revenue
+                layering recommendations.
+              </p>
+              <p className="mt-4 rounded-2xl border border-purple-200/60 bg-white/70 px-4 py-3 text-xs text-purple-700">
+                <strong className="font-semibold">Tip:</strong> The flagship offer in slot 1 is required. Supporting and entry
+                offers are optional but provide richer recommendations.
+              </p>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-3">
               {offers.map((offer) => {
                 const slotPath = `offers.${offer.slot - 1}.name`;
                 const pricePath = `offers.${offer.slot - 1}.price_point`;
                 const fulfillmentPath = `offers.${offer.slot - 1}.fulfillment_type`;
                 const outcomePath = `offers.${offer.slot - 1}.primary_outcome`;
                 return (
-                  <div key={offer.slot} className="rounded-2xl bg-white/70 p-5 shadow-sm ring-1 ring-purple-200/70">
-                    <div className="flex items-center justify-between">
-                      <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-purple-600 text-sm font-semibold text-white">
-                        {offer.slot}
-                      </span>
+                  <div
+                    key={offer.slot}
+                    className="flex flex-col gap-5 rounded-[26px] border border-purple-200/60 bg-white/95 p-6 shadow-[0_18px_38px_rgba(126,58,242,0.08)]"
+                  >
+                    <header className="space-y-1">
+                      <span className="text-xs font-semibold uppercase tracking-[0.2em] text-purple-500">Offer {offer.slot}</span>
+                      <h3 className="text-base font-semibold text-slate-900">{offerTitleMap[offer.slot]}</h3>
                       {fieldErrors[slotPath] ? (
-                        <span className="text-sm font-medium text-rose-500">{fieldErrors[slotPath]}</span>
+                        <p className="text-sm font-medium text-rose-500">{fieldErrors[slotPath]}</p>
                       ) : null}
-                    </div>
-                    <div className="mt-4 space-y-4">
+                    </header>
+
+                    <div className="space-y-4">
                       <div className="space-y-2">
-                        <label className="text-sm font-medium text-purple-900" htmlFor={`offer-name-${offer.slot}`}>
+                        <label className={fieldLabelClasses} htmlFor={`offer-name-${offer.slot}`}>
                           Offer name
                         </label>
                         <input
@@ -528,229 +557,221 @@ export default function BusinessInfoForm({ brmLevel, initialContext, initialOffe
                           name={`offers[${offer.slot}].name`}
                           type="text"
                           placeholder={offer.slot === 1 ? "Flagship program" : "Companion offer"}
-                          className={classNames(
-                            "w-full rounded-xl border border-purple-200 px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-300/60",
-                            fieldErrors[slotPath] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                          )}
+                          className={classNames(baseControlClasses, fieldErrors[slotPath] && errorControlClasses)}
                           value={offer.name}
                           onChange={(event) => handleOfferChange(offer.slot, "name", event.target.value)}
                           required={offer.slot === 1}
                         />
                       </div>
 
-                      <details className="group rounded-xl border border-purple-100 bg-purple-50/40 p-4">
-                        <summary className="flex cursor-pointer items-center justify-between text-sm font-medium text-purple-800">
-                          Details
-                          <span className="text-xs text-purple-500 group-open:hidden">Tap to expand</span>
-                          <span className="hidden text-xs text-purple-500 group-open:inline">Tap to collapse</span>
-                        </summary>
-                        <div className="mt-4 space-y-4 text-sm">
-                          <div className="space-y-1">
-                            <label className="text-purple-900" htmlFor={`offer-price-${offer.slot}`}>
-                              Price point
-                            </label>
-                            <div className="relative">
-                              <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">$
-                              </span>
-                              <input
-                                id={`offer-price-${offer.slot}`}
-                                name={`offers[${offer.slot}].price_point`}
-                                type="number"
-                                min={0}
-                                step="0.01"
-                                inputMode="decimal"
-                                placeholder={toCurrencyPlaceholder(offer.slot)}
-                                className={classNames(
-                                  "w-full rounded-lg border border-purple-200 bg-white px-3 py-2 pl-7 text-sm text-slate-900 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-300/60",
-                                  fieldErrors[pricePath] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                                )}
-                                value={offer.price_point}
-                                onChange={(event) => handleOfferChange(offer.slot, "price_point", event.target.value)}
-                              />
-                            </div>
-                            {fieldErrors[pricePath] ? (
-                              <p className="text-xs text-rose-500">{fieldErrors[pricePath]}</p>
-                            ) : null}
-                          </div>
-
-                          <div className="space-y-1">
-                            <label className="text-purple-900" htmlFor={`offer-fulfillment-${offer.slot}`}>
-                              Fulfillment style
-                            </label>
-                            <select
-                              id={`offer-fulfillment-${offer.slot}`}
-                              name={`offers[${offer.slot}].fulfillment_type`}
-                              className={classNames(
-                                "w-full rounded-lg border border-purple-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-300/60",
-                                fieldErrors[fulfillmentPath] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                              )}
-                              value={offer.fulfillment_type}
-                              onChange={(event) =>
-                                handleOfferChange(offer.slot, "fulfillment_type", event.target.value as OfferFormState["fulfillment_type"])
-                              }
-                            >
-                              <option value="">Select</option>
-                              {fulfillmentTypes.map((value) => (
-                                <option key={value} value={value}>
-                                  {formatEnumLabel(value)}
-                                </option>
-                              ))}
-                            </select>
-                            {fieldErrors[fulfillmentPath] ? (
-                              <p className="text-xs text-rose-500">{fieldErrors[fulfillmentPath]}</p>
-                            ) : null}
-                          </div>
-
-                          <div className="space-y-1">
-                            <label className="text-purple-900" htmlFor={`offer-outcome-${offer.slot}`}>
-                              Primary outcome <span className="text-xs text-purple-500">(80 characters)</span>
-                            </label>
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <label className={fieldLabelClasses} htmlFor={`offer-price-${offer.slot}`}>
+                            Price point
+                          </label>
+                          <div className="relative">
+                            <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm font-semibold text-slate-400">
+                              $
+                            </span>
                             <input
-                              id={`offer-outcome-${offer.slot}`}
-                              name={`offers[${offer.slot}].primary_outcome`}
-                              type="text"
-                              maxLength={80}
-                              placeholder="What transformation does this offer deliver?"
+                              id={`offer-price-${offer.slot}`}
+                              name={`offers[${offer.slot}].price_point`}
+                              type="number"
+                              min={0}
+                              step="0.01"
+                              inputMode="decimal"
+                              placeholder={toCurrencyPlaceholder(offer.slot)}
                               className={classNames(
-                                "w-full rounded-lg border border-purple-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-300/60",
-                                fieldErrors[outcomePath] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
+                                baseControlClasses,
+                                "pl-8",
+                                fieldErrors[pricePath] && errorControlClasses,
                               )}
-                              value={offer.primary_outcome}
-                              onChange={(event) => handleOfferChange(offer.slot, "primary_outcome", event.target.value)}
+                              value={offer.price_point}
+                              onChange={(event) => handleOfferChange(offer.slot, "price_point", event.target.value)}
                             />
-                            {fieldErrors[outcomePath] ? (
-                              <p className="text-xs text-rose-500">{fieldErrors[outcomePath]}</p>
-                            ) : null}
                           </div>
+                          {fieldErrors[pricePath] ? (
+                            <p className="text-xs text-rose-500">{fieldErrors[pricePath]}</p>
+                          ) : null}
                         </div>
-                      </details>
+
+                        <div className="space-y-2">
+                          <label className={fieldLabelClasses} htmlFor={`offer-fulfillment-${offer.slot}`}>
+                            Fulfillment style
+                          </label>
+                          <select
+                            id={`offer-fulfillment-${offer.slot}`}
+                            name={`offers[${offer.slot}].fulfillment_type`}
+                            className={classNames(baseControlClasses, fieldErrors[fulfillmentPath] && errorControlClasses)}
+                            value={offer.fulfillment_type}
+                            onChange={(event) =>
+                              handleOfferChange(
+                                offer.slot,
+                                "fulfillment_type",
+                                event.target.value as OfferFormState["fulfillment_type"],
+                              )
+                            }
+                          >
+                            <option value="">Select</option>
+                            {fulfillmentTypes.map((value) => (
+                              <option key={value} value={value}>
+                                {formatEnumLabel(value)}
+                              </option>
+                            ))}
+                          </select>
+                          {fieldErrors[fulfillmentPath] ? (
+                            <p className="text-xs text-rose-500">{fieldErrors[fulfillmentPath]}</p>
+                          ) : null}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <label className={fieldLabelClasses} htmlFor={`offer-outcome-${offer.slot}`}>
+                          Primary outcome <span className="font-normal text-xs text-slate-500">(80 characters)</span>
+                        </label>
+                        <input
+                          id={`offer-outcome-${offer.slot}`}
+                          name={`offers[${offer.slot}].primary_outcome`}
+                          type="text"
+                          maxLength={80}
+                          placeholder="What transformation does this offer deliver?"
+                          className={classNames(baseControlClasses, fieldErrors[outcomePath] && errorControlClasses)}
+                          value={offer.primary_outcome}
+                          onChange={(event) => handleOfferChange(offer.slot, "primary_outcome", event.target.value)}
+                        />
+                        {fieldErrors[outcomePath] ? (
+                          <p className="text-xs text-rose-500">{fieldErrors[outcomePath]}</p>
+                        ) : null}
+                      </div>
                     </div>
                   </div>
                 );
               })}
             </div>
-          </div>
-        </div>
+          </section>
 
-        <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-6">
-          <h2 className="text-lg font-semibold text-slate-900">Customer journey seeds</h2>
-          <p className="mt-1 text-sm text-slate-600">
-            Map how clients stay in your world so Mentors can recommend next steps.
-          </p>
-          <div className="mt-6 grid gap-5 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-900" htmlFor="retention_model">
-                Retention model
-              </label>
-              <select
-                id="retention_model"
-                name="retention_model"
-                className={classNames(
-                  "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                  fieldErrors["retention_model"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-                )}
-                value={retentionModel ?? ""}
-                onChange={(event) => setRetentionModel(event.target.value as typeof retentionModel)}
-              >
-                <option value="">Select retention style</option>
-                {retentionModels.map((value) => (
-                  <option key={value} value={value}>
-                    {formatEnumLabel(value)}
-                  </option>
-                ))}
-              </select>
+          <section className="grid gap-8 lg:grid-cols-[minmax(0,2.1fr)_minmax(0,3fr)]">
+            <div className="rounded-[28px] border border-slate-200/60 bg-gradient-to-br from-slate-50 via-white to-slate-100 p-8 shadow-inner">
+              <span className={classNames(subheadingClasses, "text-slate-500")}>Customer journey</span>
+              <h2 className="mt-3 text-2xl font-semibold text-slate-900">Clarify how clients stay engaged</h2>
+              <p className="mt-3 text-sm text-slate-600">
+                Detail retention structures and upsell paths to surface automation, nurture, and loyalty plays aligned to your
+                current systems.
+              </p>
             </div>
 
-            <div className="space-y-2">
-              <span className="text-sm font-medium text-slate-900">Do you offer upsells or downsells?</span>
-              <label className="flex w-max items-center gap-3 rounded-full bg-white px-4 py-2 shadow-sm ring-1 ring-slate-200">
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                  checked={hasUpsells}
-                  onChange={(event) => setHasUpsells(event.target.checked)}
-                />
-                <span className="text-sm text-slate-700">Yes, include upsells</span>
-              </label>
+            <div className="grid gap-6">
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className={fieldLabelClasses} htmlFor="retention_model">
+                    Retention model
+                  </label>
+                  <select
+                    id="retention_model"
+                    name="retention_model"
+                    className={classNames(baseControlClasses, fieldErrors["retention_model"] && errorControlClasses)}
+                    value={retentionModel ?? ""}
+                    onChange={(event) => setRetentionModel(event.target.value as typeof retentionModel)}
+                  >
+                    <option value="">Select retention style</option>
+                    {retentionModels.map((value) => (
+                      <option key={value} value={value}>
+                        {formatEnumLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <span className={fieldLabelClasses}>Do you offer upsells or downsells?</span>
+                  <label className="inline-flex items-center gap-3 rounded-full border border-slate-200/70 bg-white px-5 py-2.5 text-sm font-medium text-slate-600 shadow-sm transition hover:border-indigo-300">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                      checked={hasUpsells}
+                      onChange={(event) => setHasUpsells(event.target.checked)}
+                    />
+                    <span>Yes, include upsells</span>
+                  </label>
+                </div>
+              </div>
+
+              {hasUpsells ? (
+                <div className="grid gap-6 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className={fieldLabelClasses} htmlFor="upsell_name">
+                      Existing upsell/downsell name
+                    </label>
+                    <input
+                      id="upsell_name"
+                      name="upsell_name"
+                      type="text"
+                      className={baseControlClasses}
+                      value={upsellName}
+                      onChange={(event) => setUpsellName(event.target.value)}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className={fieldLabelClasses} htmlFor="upsell_timing">
+                      When is it offered?
+                    </label>
+                    <input
+                      id="upsell_timing"
+                      name="upsell_timing"
+                      type="text"
+                      className={baseControlClasses}
+                      value={upsellTiming}
+                      onChange={(event) => setUpsellTiming(event.target.value)}
+                    />
+                  </div>
+                </div>
+              ) : null}
             </div>
-          </div>
+          </section>
 
-          {hasUpsells ? (
-            <div className="mt-6 grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-900" htmlFor="upsell_name">
-                  Existing upsell/downsell name
-                </label>
-                <input
-                  id="upsell_name"
-                  name="upsell_name"
-                  type="text"
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
-                  value={upsellName}
-                  onChange={(event) => setUpsellName(event.target.value)}
-                />
-              </div>
+          <section className="rounded-[28px] border border-slate-200/70 bg-slate-50/70 p-8">
+            <span className={classNames(subheadingClasses, "text-slate-500")}>Mentor alignment</span>
+            <h2 className="mt-3 text-2xl font-semibold text-slate-900">Mentor notes &amp; momentum markers</h2>
+            <p className="mt-3 text-sm text-slate-600">
+              Share current wins, upcoming milestones, and support requests so your Mentor can tailor the next session.
+            </p>
+            <div className="mt-6 space-y-2">
+              <label className={fieldLabelClasses} htmlFor="notes">
+                Notes
+              </label>
+              <textarea
+                id="notes"
+                name="notes"
+                rows={5}
+                placeholder="Mentor notes, goals, milestones, targets (30–90 days)"
+                className={classNames(baseControlClasses, fieldErrors["notes"] && errorControlClasses, "resize-none")}
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+              />
+            </div>
+          </section>
 
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-900" htmlFor="upsell_timing">
-                  When is it offered?
-                </label>
-                <input
-                  id="upsell_timing"
-                  name="upsell_timing"
-                  type="text"
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
-                  value={upsellTiming}
-                  onChange={(event) => setUpsellTiming(event.target.value)}
-                />
-              </div>
+          {submissionError ? (
+            <div className="rounded-2xl border border-rose-200/70 bg-rose-50/80 px-5 py-4 text-sm font-medium text-rose-600">
+              {submissionError}
             </div>
           ) : null}
-        </div>
 
-        <div className="rounded-2xl border border-slate-200 bg-white p-6">
-          <h2 className="text-lg font-semibold text-slate-900">Mentor notes & momentum markers</h2>
-          <p className="mt-1 text-sm text-slate-600">
-            Capture wins, goals, or what you want your Mentor to spotlight over the next 30–90 days.
-          </p>
-          <div className="mt-4 space-y-2">
-            <label className="text-sm font-medium text-slate-900" htmlFor="notes">
-              Notes
-            </label>
-            <textarea
-              id="notes"
-              name="notes"
-              rows={5}
-              placeholder="Mentor notes, goals, milestones, targets (30–90 days)"
-              className={classNames(
-                "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60",
-                fieldErrors["notes"] && "border-rose-400 focus:border-rose-400 focus:ring-rose-200",
-              )}
-              value={notes}
-              onChange={(event) => setNotes(event.target.value)}
-            />
+          <div className="flex flex-col items-center justify-between gap-4 border-t border-slate-200 pt-6 text-sm text-slate-500 md:flex-row">
+            <p className="max-w-xl text-center md:text-left">
+              Saving keeps your Mentor aligned with what&apos;s working now so Triumph can unlock the right plays next.
+            </p>
+            <button
+              type="submit"
+              className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-7 py-3 text-sm font-semibold text-white shadow-[0_18px_35px_rgba(79,70,229,0.35)] transition hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-indigo-300"
+              disabled={isSaving}
+            >
+              {isSaving ? "Saving..." : "Save & Return to Dashboard"}
+            </button>
           </div>
-        </div>
-
-        {submissionError ? (
-          <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
-            {submissionError}
-          </div>
-        ) : null}
-
-        <div className="flex flex-col items-center justify-between gap-4 border-t border-slate-200 pt-6 text-sm text-slate-500 md:flex-row">
-          <p>
-            Saving keeps your Mentor aligned with what&#39;s working now, so Triumph can unlock the right plays next.
-          </p>
-          <button
-            type="submit"
-            className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-6 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-indigo-300"
-            disabled={isSaving}
-          >
-            {isSaving ? "Saving..." : "Save & Return to Dashboard"}
-          </button>
-        </div>
-      </form>
+        </form>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- intensify the dashboard modal overlay with stronger blur, gradient layering, and scroll handling so the background disappears when the profile launches
- widen and pad the modal container to center the experience and give the business profile room to sit above the backdrop
- wrap the business profile form in a dedicated card with responsive padding while keeping the guided section layout and validation messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b1487708832cb94afcaca49f3b83