### PR TITLE
Enhance dashboard visuals and persist active client context

### DIFF
--- a/app/(dashboard)/clients/[clientId]/ActiveClientSync.tsx
+++ b/app/(dashboard)/clients/[clientId]/ActiveClientSync.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+const ACTIVE_CLIENT_STORAGE_KEY = "tbs-active-client";
+
+type ActiveClientSyncProps = {
+  clientId: string;
+  clientName: string;
+};
+
+export default function ActiveClientSync({ clientId, clientName }: ActiveClientSyncProps) {
+  useEffect(() => {
+    const trimmedName = clientName.trim();
+
+    try {
+      window.localStorage.setItem(
+        ACTIVE_CLIENT_STORAGE_KEY,
+        JSON.stringify({
+          id: clientId,
+          name: trimmedName.length > 0 ? trimmedName : clientName,
+        }),
+      );
+    } catch (error) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("Unable to sync active client context", error);
+      }
+    }
+  }, [clientId, clientName]);
+
+  return null;
+}

--- a/app/(dashboard)/clients/[clientId]/page.tsx
+++ b/app/(dashboard)/clients/[clientId]/page.tsx
@@ -1,4 +1,6 @@
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
+import ActiveClientSync from "./ActiveClientSync";
 import PromptGenerator, { PromptContextItem } from "./PromptGenerator";
 import { getServerClient } from "@/lib/supabase-server";
 import type { PostgrestError } from "@supabase/supabase-js";
@@ -281,6 +283,20 @@ export default async function ClientDashboardPage({ params }: PageProps) {
 
   const clientName = client?.name ?? "Client";
 
+  const cookieStore = cookies();
+  cookieStore.set({
+    name: "active_client_id",
+    value: clientId,
+    path: "/",
+    sameSite: "lax",
+  });
+  cookieStore.set({
+    name: "active_client_name",
+    value: encodeURIComponent(clientName),
+    path: "/",
+    sameSite: "lax",
+  });
+
   const unlockedLevels = new Set<LevelKey>();
   (models ?? []).forEach((model) => {
     const normalized = normalizeLevel(model.level ?? null);
@@ -300,6 +316,7 @@ export default async function ClientDashboardPage({ params }: PageProps) {
 
   return (
     <main className="mx-auto flex max-w-5xl flex-col gap-8 p-6">
+      <ActiveClientSync clientId={clientId} clientName={clientName} />
       <header className="space-y-2">
         <p className="text-sm font-medium text-slate-500">Client Dashboard</p>
         <h1 className="text-2xl font-bold text-slate-900">{clientName}</h1>

--- a/app/dashboard/dashboard.css
+++ b/app/dashboard/dashboard.css
@@ -45,10 +45,34 @@
 }
 
 .dashboard-header {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
+  padding: clamp(1.1rem, 2vw, 1.6rem);
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.75));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.5);
+  overflow: hidden;
+}
+
+.dashboard-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(250, 204, 21, 0.28), transparent 55%),
+    radial-gradient(circle at 78% 18%, rgba(96, 165, 250, 0.22), transparent 60%),
+    linear-gradient(135deg, rgba(30, 64, 175, 0.45), rgba(14, 165, 233, 0.35));
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.dashboard-header > * {
+  position: relative;
+  z-index: 1;
 }
 
 .dashboard-brand {
@@ -119,20 +143,20 @@
 .primary-button {
   padding: 0.65rem 1.4rem;
   border-radius: 999px;
-  border: none;
-  background: linear-gradient(135deg, #f59e0b, #f97316);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, #f8fafc, #fef3c7 55%, #fde68a 100%);
   color: #0f172a;
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
-  box-shadow: 0 18px 45px rgba(250, 204, 21, 0.35);
+  box-shadow: 0 18px 45px rgba(250, 204, 21, 0.28);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .primary-button:hover,
 .primary-button:focus-visible {
   transform: translateY(-1px) scale(1.02);
-  box-shadow: 0 26px 60px rgba(250, 204, 21, 0.42);
+  box-shadow: 0 26px 60px rgba(250, 204, 21, 0.45);
   outline: none;
 }
 
@@ -188,19 +212,20 @@
 .secondary-button {
   padding: 0.6rem 1.3rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.45);
-  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.9));
+  color: #0f172a;
   font-weight: 500;
   letter-spacing: 0.01em;
   cursor: pointer;
-  transition: transform 0.25s ease, border-color 0.25s ease;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
 .secondary-button:hover,
 .secondary-button:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(250, 204, 21, 0.45);
+  border-color: rgba(250, 204, 21, 0.55);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
   outline: none;
 }
 

--- a/app/settings/business-info/page.tsx
+++ b/app/settings/business-info/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import BusinessInfoForm from "../../../components/BusinessInfoForm";
 import { getServerClient } from "../../../lib/supabase-server";
@@ -51,12 +52,19 @@ export default async function BusinessInfoSettingsPage() {
     ((user.user_metadata as { brm_level?: Database["public"]["Enums"]["brm_level"] } | undefined)?.brm_level ??
       BRM_LEVEL_FALLBACK);
 
+  const cookieStore = cookies();
+  const activeClientId = cookieStore.get("active_client_id")?.value ?? null;
+  const activeClientNameCookie = cookieStore.get("active_client_name")?.value ?? null;
+  const activeClientName = activeClientNameCookie ? decodeURIComponent(activeClientNameCookie) : null;
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-indigo-50 px-4 py-12">
       <BusinessInfoForm
         brmLevel={brmLevel}
         initialContext={contextData ?? null}
         initialOffers={offerData ?? []}
+        activeClientId={activeClientId}
+        activeClientName={activeClientName}
       />
     </main>
   );


### PR DESCRIPTION
## Summary
- Refresh the dashboard header with a brand-aligned gradient panel and improve button contrast with dark typography.
- Persist the selected client between dashboard and settings by syncing cookies and local storage.
- Surface the active client within the business info form so settings reflect the current dashboard selection.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e3dfaf3598832ca5a63326e7f5b2f8