### PR TITLE
Rebuild client dashboard in Triumph style

### DIFF
--- a/app/client/BusinessProfileForm.tsx
+++ b/app/client/BusinessProfileForm.tsx
@@ -213,14 +213,18 @@ export default function BusinessProfileForm() {
   };
 
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
-      <div className="flex flex-col gap-6 px-8 py-10">
-        <div className="max-w-2xl space-y-3">
-          <div className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+    <section className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_45px_140px_rgba(1,9,30,0.35)]">
+      <div className="pointer-events-none absolute inset-0 opacity-60">
+        <div className="absolute -top-32 left-8 h-64 w-64 rounded-full bg-[#004aad]/40 blur-3xl" />
+        <div className="absolute bottom-[-6rem] right-[-4rem] h-80 w-80 rounded-full bg-[#fa9100]/30 blur-[140px]" />
+      </div>
+      <div className="relative flex flex-col gap-8 px-8 py-12 md:px-12">
+        <div className="max-w-2xl space-y-4">
+          <div className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-white/80">
             Business Foundations
           </div>
-          <h2 className="text-2xl font-semibold text-slate-900">Share your business story</h2>
-          <p className="text-sm leading-relaxed text-slate-600">
+          <h2 className="text-3xl font-semibold text-slate-50">Share your business story</h2>
+          <p className="text-sm leading-relaxed text-slate-300">
             Give your Triumph mentor the context they need to champion you throughout the program. A rich profile keeps every planning session, prompt, and milestone aligned with what matters most to your business.
           </p>
         </div>
@@ -231,8 +235,8 @@ export default function BusinessProfileForm() {
             aria-live="polite"
             className={`rounded-2xl border px-4 py-3 text-sm font-medium transition ${
               status.type === "success"
-                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-                : "border-red-200 bg-red-50 text-red-700"
+                ? "border-emerald-400/40 bg-emerald-400/15 text-emerald-200"
+                : "border-rose-400/40 bg-rose-500/15 text-rose-200"
             }`}
           >
             {status.message}
@@ -240,7 +244,7 @@ export default function BusinessProfileForm() {
         ) : null}
 
         {isLoading ? (
-          <p className="text-sm font-medium text-slate-500">Loading your business profile…</p>
+          <p className="text-sm font-medium text-slate-300">Loading your business profile…</p>
         ) : null}
 
         <form
@@ -249,7 +253,7 @@ export default function BusinessProfileForm() {
         >
           <div className="flex flex-col gap-2">
             <label
-              className="text-sm font-semibold text-slate-700"
+              className="text-sm font-semibold text-slate-200"
               htmlFor="business_name"
             >
               Business name
@@ -262,12 +266,12 @@ export default function BusinessProfileForm() {
               value={profile.business_name ?? ""}
               onChange={(event) => handleChange("business_name", event.target.value)}
               disabled={isLoading || isSaving}
-              className="h-12 w-full rounded-xl border border-slate-200 px-4 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+              className="h-12 w-full rounded-xl border border-white/15 bg-slate-950/70 px-4 text-sm text-slate-100 shadow-[0_16px_40px_rgba(2,10,36,0.45)] transition focus:border-[#fa9100] focus:outline-none focus:ring-2 focus:ring-[#fa9100]/30 disabled:cursor-not-allowed disabled:bg-slate-900/60"
             />
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-sm font-semibold text-slate-700" htmlFor="industry">
+            <label className="text-sm font-semibold text-slate-200" htmlFor="industry">
               Industry
             </label>
             <input
@@ -278,13 +282,13 @@ export default function BusinessProfileForm() {
               value={profile.industry ?? ""}
               onChange={(event) => handleChange("industry", event.target.value)}
               disabled={isLoading || isSaving}
-              className="h-12 w-full rounded-xl border border-slate-200 px-4 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+              className="h-12 w-full rounded-xl border border-white/15 bg-slate-950/70 px-4 text-sm text-slate-100 shadow-[0_16px_40px_rgba(2,10,36,0.45)] transition focus:border-[#fa9100] focus:outline-none focus:ring-2 focus:ring-[#fa9100]/30 disabled:cursor-not-allowed disabled:bg-slate-900/60"
             />
           </div>
 
           <div className="flex flex-col gap-2">
             <label
-              className="text-sm font-semibold text-slate-700"
+              className="text-sm font-semibold text-slate-200"
               htmlFor="business_type"
             >
               Business type
@@ -295,7 +299,7 @@ export default function BusinessProfileForm() {
               value={profile.business_type ?? ""}
               onChange={(event) => handleChange("business_type", event.target.value)}
               disabled={isLoading || isSaving}
-              className="h-12 w-full rounded-xl border border-slate-200 px-4 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+              className="h-12 w-full rounded-xl border border-white/15 bg-slate-950/70 px-4 text-sm text-slate-100 shadow-[0_16px_40px_rgba(2,10,36,0.45)] transition focus:border-[#fa9100] focus:outline-none focus:ring-2 focus:ring-[#fa9100]/30 disabled:cursor-not-allowed disabled:bg-slate-900/60"
             >
               <option value="">Select type</option>
               {BUSINESS_TYPE_OPTIONS.map((option) => (
@@ -306,17 +310,17 @@ export default function BusinessProfileForm() {
             </select>
           </div>
 
-          <fieldset className="col-span-full rounded-2xl border border-slate-200 bg-slate-50/60 p-6">
-            <legend className="px-2 text-sm font-semibold uppercase tracking-wide text-indigo-700">
+          <fieldset className="col-span-full rounded-2xl border border-white/10 bg-slate-950/60 p-6">
+            <legend className="px-2 text-sm font-semibold uppercase tracking-[0.28em] text-white/70">
               Top services & programs
             </legend>
-            <p className="mt-2 text-xs text-slate-500">
-              Highlight up to three flagship offers. We&#39;ll reference these individually across materials, recaps, and mentor planning.
+            <p className="mt-2 text-xs text-slate-400">
+              Highlight up to three flagship offers. We’ll reference these individually across materials, recaps, and mentor planning.
             </p>
             <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
               {SERVICE_PROGRAM_FIELDS.map(({ key, label, placeholder }) => (
                 <div key={key} className="flex flex-col gap-2">
-                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-600" htmlFor={key}>
+                  <label className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400" htmlFor={key}>
                     {label}
                   </label>
                   <input
@@ -327,7 +331,7 @@ export default function BusinessProfileForm() {
                     value={profile[key] ?? ""}
                     onChange={(event) => handleChange(key, event.target.value)}
                     disabled={isLoading || isSaving}
-                    className="h-12 w-full rounded-xl border border-slate-200 bg-white px-4 text-sm text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+                    className="h-12 w-full rounded-xl border border-white/10 bg-slate-950/70 px-4 text-sm text-slate-100 shadow-[0_12px_32px_rgba(2,10,36,0.45)] transition focus:border-[#fa9100] focus:outline-none focus:ring-2 focus:ring-[#fa9100]/30 disabled:cursor-not-allowed disabled:bg-slate-900/60"
                   />
                 </div>
               ))}
@@ -336,7 +340,7 @@ export default function BusinessProfileForm() {
 
           <div className="col-span-full flex flex-col gap-2">
             <label
-              className="text-sm font-semibold text-slate-700"
+              className="text-sm font-semibold text-slate-200"
               htmlFor="key_details"
             >
               Program notes & momentum markers
@@ -348,18 +352,18 @@ export default function BusinessProfileForm() {
               value={profile.key_details ?? ""}
               onChange={(event) => handleChange("key_details", event.target.value)}
               disabled={isLoading || isSaving}
-              className="min-h-[160px] w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm leading-6 text-slate-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-slate-100"
+              className="min-h-[160px] w-full rounded-2xl border border-white/15 bg-slate-950/70 px-4 py-3 text-sm leading-6 text-slate-100 shadow-[0_20px_50px_rgba(2,10,36,0.45)] transition focus:border-[#fa9100] focus:outline-none focus:ring-2 focus:ring-[#fa9100]/30 disabled:cursor-not-allowed disabled:bg-slate-900/60"
             />
           </div>
 
           <div className="col-span-full flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               Updates save instantly for your mentor and the Triumph team to reference across the program.
             </p>
             <button
               type="submit"
               disabled={isLoading || isSaving}
-              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-indigo-600 via-purple-600 to-rose-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:from-indigo-300 disabled:via-purple-300 disabled:to-rose-300"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#fa9100] via-[#ffb341] to-[#8fd6ff] px-7 py-3 text-sm font-semibold text-slate-950 shadow-[0_25px_70px_rgba(250,145,0,0.35)] transition hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[#fa9100]/40 focus:ring-offset-2 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isSaving ? "Saving…" : "Save business profile"}
             </button>

--- a/app/client/components/ModelPanel.tsx
+++ b/app/client/components/ModelPanel.tsx
@@ -32,55 +32,134 @@ type ModelPanelProps = {
 
 export function ModelPanel({ model, milestones, kpis, actions }: ModelPanelProps) {
   const levelLabel = model.level ? model.level.toUpperCase() : "Model";
+  const completedMilestones = milestones.filter((milestone) => milestone.done).length;
+  const totalMilestones = milestones.length;
+  const milestoneCompletion =
+    totalMilestones > 0 ? Math.round((completedMilestones / totalMilestones) * 100) : 0;
 
   return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Model</p>
-          <h3 className="text-lg font-semibold text-slate-900">
-            {levelLabel}
-            {model.status ? (
-              <span className="ml-2 text-sm font-medium uppercase tracking-wide text-slate-500">
-                {model.status}
-              </span>
-            ) : null}
-          </h3>
-        </div>
-        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
-      </header>
+    <section className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-slate-950/60 p-8 shadow-[0_45px_120px_rgba(1,9,30,0.35)] transition-all hover:border-white/20">
+      <div className="pointer-events-none absolute inset-0 opacity-60">
+        <div className="absolute -top-24 right-0 h-60 w-60 rounded-full bg-[#fa9100]/30 blur-3xl transition group-hover:opacity-80" />
+        <div className="absolute bottom-0 left-0 h-64 w-64 rounded-full bg-[#004aad]/35 blur-3xl transition group-hover:opacity-90" />
+      </div>
 
-      <div className="mt-4 grid gap-6 md:grid-cols-2">
-        <div>
-          <h4 className="text-sm font-semibold text-slate-700">Milestones</h4>
-          {milestones.length === 0 ? (
-            <p className="mt-2 text-sm text-slate-500">No milestones.</p>
-          ) : (
-            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-700">
-              {milestones.map((milestone) => (
-                <li key={milestone.id}>
-                  <span>{milestone.title ?? "Untitled milestone"}</span>
-                  {milestone.done ? <span className="ml-2">✅</span> : null}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+      <div className="relative space-y-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[#8fd6ff]/80">Model</p>
+            <h3 className="text-2xl font-semibold text-slate-100">
+              {levelLabel}
+              {model.status ? (
+                <span className="ml-3 inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-100/80">
+                  {model.status}
+                </span>
+              ) : null}
+            </h3>
+          </div>
+          {actions ? <div className="flex items-center gap-2 text-slate-100">{actions}</div> : null}
+        </header>
 
         <div>
-          <h4 className="text-sm font-semibold text-slate-700">KPIs</h4>
-          {kpis.length === 0 ? (
-            <p className="mt-2 text-sm text-slate-500">No KPIs.</p>
-          ) : (
-            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-700">
-              {kpis.map((kpi) => (
-                <li key={kpi.id}>
-                  <span className="font-medium">{kpi.key ?? "KPI"}</span>: {kpi.value ?? "—"} / {kpi.target ?? "—"}
-                  {kpi.period ? <span className="ml-1 text-slate-500">({kpi.period})</span> : null}
-                </li>
-              ))}
-            </ul>
-          )}
+          <div className="flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-slate-300/80">
+            <span>Milestone Progress</span>
+            <span>
+              {completedMilestones}/{totalMilestones || 0}
+            </span>
+          </div>
+          <div className="mt-3 h-2.5 w-full overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-[#fa9100] via-[#ffb341] to-[#8fd6ff]"
+              style={{ width: `${milestoneCompletion}%` }}
+            />
+          </div>
+          <p className="mt-2 text-sm text-slate-300">
+            {milestoneCompletion}% of milestones complete
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <h4 className="text-sm font-semibold text-slate-100">Milestones</h4>
+            {milestones.length === 0 ? (
+              <p className="mt-3 rounded-2xl border border-dashed border-white/20 bg-white/5 p-4 text-sm text-slate-300">
+                No milestones yet. Add your first step to unlock progress tracking.
+              </p>
+            ) : (
+              <ul className="mt-3 space-y-3 text-sm text-slate-200">
+                {milestones.map((milestone) => {
+                  const done = Boolean(milestone.done);
+
+                  return (
+                    <li
+                      key={milestone.id}
+                      className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/[0.06] p-4 shadow-[0_12px_40px_rgba(2,8,28,0.55)]"
+                    >
+                      <span
+                        className={`mt-0.5 h-2.5 w-2.5 flex-shrink-0 rounded-full ${
+                          done ? "bg-emerald-400" : "bg-white/30"
+                        }`}
+                        aria-hidden
+                      />
+                      <div>
+                        <p className="font-medium text-slate-100">
+                          {milestone.title ?? "Untitled milestone"}
+                        </p>
+                        <p className="text-xs uppercase tracking-wide text-slate-400/80">
+                          {done ? "Completed" : "In progress"}
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <h4 className="text-sm font-semibold text-slate-100">KPIs</h4>
+            {kpis.length === 0 ? (
+              <p className="mt-3 rounded-2xl border border-dashed border-white/20 bg-white/5 p-4 text-sm text-slate-300">
+                No KPIs yet. Capture the metrics that define success for this model.
+              </p>
+            ) : (
+              <ul className="mt-3 space-y-3 text-sm text-slate-200">
+                {kpis.map((kpi) => {
+                  const hasTargets = kpi.target != null && kpi.value != null;
+                  const onTrack = hasTargets ? Number(kpi.value) >= Number(kpi.target) : false;
+
+                  return (
+                    <li
+                      key={kpi.id}
+                      className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.06] p-4 shadow-[0_12px_40px_rgba(2,8,28,0.55)]"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="font-medium text-slate-100">{kpi.key ?? "KPI"}</span>
+                        {hasTargets ? (
+                          <span
+                            className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold ${
+                              onTrack
+                                ? "bg-emerald-400/20 text-emerald-200"
+                                : "bg-amber-400/20 text-amber-200"
+                            }`}
+                          >
+                            {onTrack ? "On track" : "Needs focus"}
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="text-sm text-slate-300">
+                        {kpi.value ?? "—"}
+                        {hasTargets ? <span className="text-slate-400">/{kpi.target}</span> : null}
+                        {kpi.period ? (
+                          <span className="ml-2 text-xs uppercase tracking-wide text-slate-400/80">{kpi.period}</span>
+                        ) : null}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/app/client/page.tsx
+++ b/app/client/page.tsx
@@ -27,39 +27,114 @@ function Layout({
   children?: ReactNode;
   showBusinessProfileForm: boolean;
 }) {
+  const introTitle = showBusinessProfileForm ? "Let's get your business ready" : "Welcome back";
+  const introSubtitle = showBusinessProfileForm
+    ? "Complete your business information so we can tailor your Triumph BRM journey to the goals that matter most."
+    : "This dashboard keeps your Triumph mentor aligned with where your business is today and where you’re headed next. Keep your profile fresh so our program resources stay tailored to your goals.";
+  const nextStepTitle = showBusinessProfileForm ? "Complete your business profile" : "Share your latest updates";
+  const nextStepDescription = showBusinessProfileForm
+    ? "A filled-in profile unlocks personalized models, KPIs, and mentor prompts for your launch."
+    : "Refreshing your details keeps Triumph mentors focused on the momentum that matters most.";
+
+  const quickStats = [
+    {
+      title: "Profile status",
+      value: showBusinessProfileForm ? "Setup needed" : "Profile synced",
+      description: showBusinessProfileForm
+        ? "Add your business foundations so we can personalize your roadmap."
+        : "Your mentor is working with your latest snapshot—keep it rolling!",
+      tint: "bg-[#fa9100]/35",
+    },
+    {
+      title: "Mentor alignment",
+      value: showBusinessProfileForm ? "Kickoff pending" : "Active guidance",
+      description: showBusinessProfileForm
+        ? "Finish onboarding to activate Triumph mentor support."
+        : "Expect proactive nudges and resources tuned to your journey.",
+      tint: "bg-[#004aad]/40",
+    },
+    {
+      title: "Workspace focus",
+      value: showBusinessProfileForm ? "Start with Business Profile" : "Review models weekly",
+      description: showBusinessProfileForm
+        ? "Set the tone for your BRM workspace by sharing your core offers."
+        : "Celebrate progress, adjust KPIs, and plan the next momentum markers.",
+      tint: "bg-[#8fd6ff]/40",
+    },
+  ];
+
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-indigo-50 px-4 py-12">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
-        <header className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
-          <div className="space-y-3">
-            <h1 className="text-3xl font-semibold text-slate-900">Welcome back</h1>
-            <p className="text-base leading-relaxed text-slate-600">
-              This dashboard keeps your Triumph mentor aligned with where your business is today and where you’re headed next.
-              Keep your profile fresh so our program resources stay tailored to your goals.
-            </p>
+    <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute -top-40 left-1/2 h-[620px] w-[620px] -translate-x-1/2 bg-[#004aad]/35 blur-[160px]" />
+        <div className="absolute bottom-[-12rem] right-[-8rem] h-[520px] w-[520px] bg-[#fa9100]/25 blur-[180px]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(143,214,255,0.12),_transparent_65%)]" />
+      </div>
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-16 lg:px-6">
+        <header className="relative overflow-hidden rounded-[40px] border border-white/15 bg-white/5 px-8 py-12 shadow-[0_60px_160px_rgba(1,9,30,0.55)] backdrop-blur-xl md:px-12">
+          <div className="pointer-events-none absolute inset-0 opacity-70">
+            <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#fa9100]/35 blur-[120px]" />
+            <div className="absolute bottom-[-6rem] left-[-4rem] h-72 w-72 rounded-full bg-[#004aad]/40 blur-[140px]" />
           </div>
-          <Link
-            href="/client/settings"
-            className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-          >
-            <svg
-              aria-hidden
-              viewBox="0 0 24 24"
-              className="h-5 w-5 text-slate-500"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M10.5 6h3l.879 1.758a2 2 0 0 0 1.341 1.077l1.903.475-1.365 2.047a2 2 0 0 0 0 2.286l1.365 2.047-1.903.475a2 2 0 0 0-1.341 1.077L13.5 18h-3l-.879-1.758a2 2 0 0 0-1.341-1.077l-1.903-.475 1.365-2.047a2 2 0 0 0 0-2.286L7.377 9.31l1.903-.475a2 2 0 0 0 1.341-1.077L10.5 6Z"
-              />
-              <circle cx="12" cy="12" r="2" />
-            </svg>
-            Settings
-          </Link>
+          <div className="relative flex flex-col gap-10 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-2xl space-y-6">
+              <span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-white/80">
+                Triumph client workspace
+              </span>
+              <div className="space-y-4">
+                <h1 className="text-3xl font-semibold md:text-4xl">{introTitle}</h1>
+                <p className="text-base leading-relaxed text-slate-200/80">{introSubtitle}</p>
+              </div>
+              <ul className="grid gap-3 text-sm text-slate-200/90 sm:grid-cols-2">
+                <li className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-3 shadow-[0_20px_60px_rgba(2,10,36,0.4)]">
+                  <span className="mt-1 h-2.5 w-2.5 rounded-full bg-[#fa9100]" aria-hidden />
+                  <div className="space-y-1">
+                    <p className="font-semibold text-slate-100">Guided growth checkpoints</p>
+                    <p className="text-xs text-slate-300/90">Follow curated milestones co-created with Triumph mentors.</p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-3 shadow-[0_20px_60px_rgba(2,10,36,0.4)]">
+                  <span className="mt-1 h-2.5 w-2.5 rounded-full bg-[#8fd6ff]" aria-hidden />
+                  <div className="space-y-1">
+                    <p className="font-semibold text-slate-100">Revenue clarity at a glance</p>
+                    <p className="text-xs text-slate-300/90">Track KPIs, services, and wins without leaving your workspace.</p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div className="flex w-full max-w-sm flex-col gap-4 text-sm lg:w-auto">
+              <div className="rounded-3xl border border-white/10 bg-white/10 px-5 py-4 text-left text-slate-100 shadow-[0_25px_80px_rgba(2,10,36,0.45)]">
+                <p className="text-xs uppercase tracking-[0.32em] text-white/60">Next step</p>
+                <p className="mt-2 text-base font-semibold text-white">{nextStepTitle}</p>
+                <p className="mt-3 text-xs leading-relaxed text-slate-200/80">{nextStepDescription}</p>
+              </div>
+              <Link
+                href="/client/settings"
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#fa9100] via-[#ffb341] to-[#8fd6ff] px-6 py-3 text-sm font-semibold text-slate-950 shadow-[0_25px_70px_rgba(250,145,0,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              >
+                Manage account settings
+              </Link>
+            </div>
+          </div>
         </header>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          {quickStats.map((stat) => (
+            <article
+              key={stat.title}
+              className="relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-6 text-sm shadow-[0_35px_120px_rgba(1,9,30,0.4)] backdrop-blur"
+            >
+              <div className="pointer-events-none absolute inset-0 opacity-70">
+                <div className={`absolute -top-10 right-0 h-36 w-36 rounded-full ${stat.tint} blur-3xl`} />
+              </div>
+              <div className="relative space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">{stat.title}</p>
+                <p className="text-2xl font-semibold text-slate-100">{stat.value}</p>
+                <p className="text-xs text-slate-300/90">{stat.description}</p>
+              </div>
+            </article>
+          ))}
+        </section>
 
         {showBusinessProfileForm ? <BusinessProfileForm /> : null}
 
@@ -85,9 +160,9 @@ function renderErrors(errors: string[]) {
   }
 
   return (
-    <div className="rounded-2xl border border-red-200 bg-red-50/80 p-4 text-sm text-red-700 shadow-sm">
-      <p className="font-semibold">There was a problem loading client data.</p>
-      <ul className="mt-2 list-disc space-y-1 pl-5">
+    <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-100 shadow-[0_20px_60px_rgba(112,26,67,0.45)]">
+      <p className="font-semibold text-rose-50">There was a problem loading client data.</p>
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-rose-100/90">
         {errors.map((message, index) => (
           <li key={index}>{message}</li>
         ))}
@@ -98,8 +173,8 @@ function renderErrors(errors: string[]) {
 
 const overviewHeader = (
   <div className="space-y-2">
-    <h2 className="text-xl font-semibold tracking-tight text-slate-900">My BRM Progress</h2>
-    <p className="text-sm text-slate-600">
+    <h2 className="text-xl font-semibold tracking-tight text-slate-50">My BRM Progress</h2>
+    <p className="text-sm text-slate-300/90">
       Snapshot of models, milestones, and KPIs aligned to your current Triumph plan.
     </p>
   </div>
@@ -107,18 +182,23 @@ const overviewHeader = (
 
 function BusinessInformationPrompt({ href }: { href: string }) {
   return (
-    <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-amber-900">
-      <h3 className="text-lg font-semibold">Complete your business information</h3>
-      <p className="mt-2 text-sm">
-        Tell us about your business so we can tailor your BRM roadmap and surface the most relevant
-        models, milestones, and KPIs for you.
-      </p>
-      <Link
-        href={href}
-        className="mt-4 inline-flex items-center justify-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600"
-      >
-        Fill out the Business Information form
-      </Link>
+    <section className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 p-6 text-slate-100 shadow-[0_35px_120px_rgba(1,9,30,0.45)]">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="absolute -top-14 right-0 h-44 w-44 rounded-full bg-[#fa9100]/30 blur-[120px]" />
+        <div className="absolute bottom-[-6rem] left-[-3rem] h-60 w-60 rounded-full bg-[#004aad]/35 blur-[140px]" />
+      </div>
+      <div className="relative space-y-4">
+        <h3 className="text-lg font-semibold text-slate-50">Complete your business information</h3>
+        <p className="text-sm leading-relaxed text-slate-200/80">
+          Tell us about your business so we can tailor your BRM roadmap and surface the most relevant models, milestones, and KPIs for you.
+        </p>
+        <Link
+          href={href}
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#fa9100] via-[#ffb341] to-[#8fd6ff] px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_25px_70px_rgba(250,145,0,0.35)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Fill out the Business Information form
+        </Link>
+      </div>
     </section>
   );
 }
@@ -134,7 +214,7 @@ export default async function ClientDashboardPage() {
     return (
       <Layout showBusinessProfileForm>
         {renderErrors(errors)}
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-slate-300/80">
           Unable to load client data because Supabase environment variables are missing.
         </p>
       </Layout>
@@ -177,7 +257,7 @@ export default async function ClientDashboardPage() {
     return (
       <Layout showBusinessProfileForm>
         {renderErrors(errors)}
-        <p className="text-sm text-slate-500">No client found.</p>
+        <p className="text-sm text-slate-300/80">No client found.</p>
       </Layout>
     );
   }
@@ -218,6 +298,43 @@ export default async function ClientDashboardPage() {
   const milestonesByModel = groupByModel(milestones);
   const kpisByModel = groupByModel(kpis);
 
+  const totalMilestones = milestones.length;
+  const completedMilestones = milestones.filter((milestone) => milestone.done).length;
+  const milestoneCompletion =
+    totalMilestones > 0 ? Math.round((completedMilestones / totalMilestones) * 100) : 0;
+  const upcomingMilestones = milestones.filter((milestone) => !milestone.done).length;
+  const trackedKpis = kpis.filter((kpi) => kpi.target != null || kpi.value != null);
+  const onTrackKpis = trackedKpis.filter(
+    (kpi) => kpi.target != null && kpi.value != null && Number(kpi.value) >= Number(kpi.target),
+  ).length;
+
+  const summaryCards = [
+    {
+      title: "Models in motion",
+      value: models.length,
+      description: "Active BRM pillars guiding your progress right now.",
+      tint: "bg-[#fa9100]/35",
+    },
+    {
+      title: "Milestone completion",
+      value: `${milestoneCompletion}%`,
+      description: `${completedMilestones} of ${totalMilestones || 0} steps complete across all models.`,
+      tint: "bg-[#8fd6ff]/35",
+    },
+    {
+      title: "Upcoming milestones",
+      value: upcomingMilestones,
+      description: "Keep momentum by closing out these next high-impact tasks.",
+      tint: "bg-[#004aad]/35",
+    },
+    {
+      title: "KPIs with targets",
+      value: trackedKpis.length,
+      description: `${onTrackKpis} currently meeting or exceeding goals.`,
+      tint: "bg-[#ffb341]/35",
+    },
+  ];
+
   const showBusinessInformationPrompt =
     businessInfoFieldAvailable && client.business_information_completed_at == null;
   const businessInformationFormHref = "/client/settings";
@@ -227,13 +344,35 @@ export default async function ClientDashboardPage() {
 
   return (
     <Layout showBusinessProfileForm={showBusinessProfileForm}>
-      <section className="rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-lg backdrop-blur">
-        <div className="flex flex-col gap-6">
+      <section className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 p-8 shadow-[0_45px_140px_rgba(1,9,30,0.45)] backdrop-blur">
+        <div className="pointer-events-none absolute inset-0 opacity-50">
+          <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#8fd6ff]/25 blur-[140px]" />
+          <div className="absolute bottom-[-8rem] left-[-4rem] h-72 w-72 rounded-full bg-[#004aad]/35 blur-[160px]" />
+        </div>
+        <div className="relative flex flex-col gap-10">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             {overviewHeader}
-            <div className="text-sm text-slate-500">
-              Client: <span className="font-medium text-slate-900">{client.name}</span>
+            <div className="rounded-full border border-white/10 bg-white/10 px-5 py-2 text-sm text-slate-200/80 shadow-[0_18px_60px_rgba(2,10,36,0.45)]">
+              Client: <span className="font-semibold text-white">{client.name}</span>
             </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {summaryCards.map((card) => (
+              <article
+                key={card.title}
+                className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-5 text-sm shadow-[0_30px_110px_rgba(1,9,30,0.4)] transition hover:border-white/20"
+              >
+                <div className="pointer-events-none absolute inset-0 opacity-70">
+                  <div className={`absolute -top-10 right-0 h-32 w-32 rounded-full ${card.tint} blur-3xl`} />
+                </div>
+                <div className="relative space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">{card.title}</p>
+                  <p className="text-3xl font-semibold text-slate-100">{card.value}</p>
+                  <p className="text-sm text-slate-300/90">{card.description}</p>
+                </div>
+              </article>
+            ))}
           </div>
 
           {renderErrors(errors)}
@@ -243,13 +382,16 @@ export default async function ClientDashboardPage() {
           ) : null}
 
           {models.length === 0 ? (
-            <p className="text-sm text-slate-500">
-              {showBusinessInformationPrompt
-                ? "We’ll populate your BRM plan after you complete the Business Information form."
-                : "No models yet."}
-            </p>
+            <div className="rounded-[28px] border border-dashed border-white/15 bg-white/5 p-10 text-center text-sm text-slate-300/90 shadow-[0_30px_110px_rgba(1,9,30,0.4)]">
+              <p className="font-medium text-slate-100">You&apos;re all set to begin.</p>
+              <p className="mt-2 text-slate-300/80">
+                {showBusinessInformationPrompt
+                  ? "We’ll populate your BRM plan after you complete the Business Information form."
+                  : "Add your first model to start tracking milestones and KPIs."}
+              </p>
+            </div>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-6">
               {models.map((model) => (
                 <ModelPanel
                   key={model.id}


### PR DESCRIPTION
## Summary
- align the client dashboard shell with the login scene by adding a neon hero, background gradients, and quick stats
- restyle the business profile form to match the dark Triumph aesthetic with glowing inputs and statuses
- refresh model panels to feature gradient progress indicators and elevated milestone/KPI cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f8aec530832cb4b9a542212326e0