### PR TITLE
Redirect dashboard route to mentor home

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,11 @@ The app uses the Next.js App Router located in the `app/` directory. Update page
 
 ⸻
 
+### Role-based dashboards
+
+Different Supabase roles land on dedicated workspaces. See [docs/role-portals.md](docs/role-portals.md) for the redirect map, source files, and notes about each experience.
+
+⸻
 
 
 Triumph BRM Companion App

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,9 +4,6 @@ import { redirect } from "next/navigation";
 import { PENDING_APPROVAL_ROUTE, resolveRoleRedirect } from "@/lib/auth";
 import { getServerClient } from "@/lib/supabase-server";
 
-import "./dashboard.css";
-import DashboardClient from "./DashboardClient";
-
 export const metadata: Metadata = {
   title: "Dashboard | Business Revenue Model App",
 };
@@ -15,7 +12,7 @@ export default async function DashboardPage() {
   const supabase = getServerClient();
 
   if (!supabase) {
-    return <DashboardClient />;
+    redirect("/mentor/home");
   }
 
   const {
@@ -33,6 +30,5 @@ export default async function DashboardPage() {
     console.error("[dashboard] Failed to resolve role redirect", error);
     redirect(PENDING_APPROVAL_ROUTE);
   }
-
-  return <DashboardClient />;
+  return null;
 }

--- a/docs/role-portals.md
+++ b/docs/role-portals.md
@@ -1,0 +1,13 @@
+# Role portals and dashboard destinations
+
+This app relies on Supabase role claims to decide which workspace to show after login. The mapping logic lives in `lib/auth.ts` and drives the redirects from `/dashboard` and the login flow. At a glance:
+
+| Role claim | Redirect destination | Top-level page component | Notes |
+| --- | --- | --- | --- |
+| `mentor_admin` | `/mentor/home` | [`app/mentor/home/page.tsx`](../app/mentor/home/page.tsx) | Loads mentor data and renders the shared mentor dashboard view. |
+| `mentor` | `/mentor/home` | [`app/mentor/home/page.tsx`](../app/mentor/home/page.tsx) | Mentors and mentor admins land on the same workspace experience. |
+| `client` | `/client` | [`app/client/page.tsx`](../app/client/page.tsx) | Shows the client-facing workspace with BRM progress, KPIs, and setup prompts. |
+| _(fallback)_ | `/pending-approval` | _not yet implemented_ | When no role is present we redirect here until access is resolved. |
+
+The redirect map comes from `ROLE_DESTINATION_MAP` inside `lib/auth.ts`, and the `resolveRoleRedirect` helper consolidates the role values from Supabase metadata or the `profiles` table before deciding where to send the user. Both the server-only `/dashboard` route and the `useRoleRedirect` client hook call this helper so the experience is consistent whether navigation happens during SSR or after an auth state change.
+


### PR DESCRIPTION
## Summary
- redirect the /dashboard route to the mentor home when Supabase is not configured
- remove the legacy dashboard fallback component so mentors always see the new workspace

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e57bcb3f9c832caf3da4257f61b6af