### PR TITLE
Add dedicated registration experience with plan selection

### DIFF
--- a/app/login/login.css
+++ b/app/login/login.css
@@ -329,6 +329,114 @@
   gap: 0.4rem;
 }
 
+.field-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 1.4rem;
+  background: rgba(5, 9, 19, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  gap: 1.25rem;
+}
+
+.fieldset legend {
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(248, 249, 252, 0.72);
+  padding: 0 0.35rem;
+}
+
+.plan-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.plan-card {
+  position: relative;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(3, 6, 16, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.plan-card:hover {
+  border-color: rgba(250, 145, 0, 0.45);
+  transform: translateY(-1px);
+}
+
+.plan-card input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.plan-card__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.plan-card__price {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(248, 249, 252, 0.8);
+}
+
+.plan-card__description,
+.plan-card__details {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.plan-card.is-selected {
+  border-color: rgba(250, 145, 0, 0.75);
+  box-shadow: 0 20px 48px rgba(5, 16, 45, 0.55);
+  transform: translateY(-2px);
+}
+
+.plan-addon {
+  margin-top: 0.6rem;
+}
+
+.help-text {
+  margin: 0.4rem 0 0;
+  font-size: 0.82rem;
+  color: rgba(232, 236, 250, 0.7);
+}
+
+.plan-summary {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(5, 9, 19, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.92rem;
+}
+
+.plan-summary strong {
+  color: #fff;
+}
+
+.success-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(143, 214, 255, 0.95);
+  font-weight: 500;
+}
+
 .field label {
   font-size: 0.85rem;
   letter-spacing: 0.08em;
@@ -521,6 +629,12 @@
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@media (min-width: 680px) {
+  .plan-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/app/register/RegisterForm.tsx
+++ b/app/register/RegisterForm.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useMemo, useState } from "react";
+
+type AccountType = "single" | "multi";
+
+type FormState = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  companyName: string;
+  accountType: AccountType;
+  companiesIncluded: number;
+};
+
+const defaultState: FormState = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  companyName: "",
+  accountType: "single",
+  companiesIncluded: 3,
+};
+
+const accountOptions: Array<{
+  id: AccountType;
+  label: string;
+  price: string;
+  description: string;
+  details: string;
+}> = [
+  {
+    id: "single",
+    label: "Single Business Owner",
+    price: "$49 / month",
+    description: "Perfect for founders building momentum in one company.",
+    details: "Includes one active company workspace with mentor collaboration.",
+  },
+  {
+    id: "multi",
+    label: "Multi-Company Suite",
+    price: "$99 / month",
+    description: "Ideal for mentors and operators supporting multiple brands.",
+    details: "Covers up to three companies, then $39 / month for each additional company.",
+  },
+];
+
+export default function RegisterForm() {
+  const [form, setForm] = useState<FormState>(defaultState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionMessage, setSubmissionMessage] = useState<string | null>(null);
+
+  const totalEstimate = useMemo(() => {
+    if (form.accountType === "single") {
+      return 49;
+    }
+
+    const includedCompanies = 3;
+    if (form.companiesIncluded <= includedCompanies) {
+      return 99;
+    }
+
+    const additionalCompanies = form.companiesIncluded - includedCompanies;
+    return 99 + additionalCompanies * 39;
+  }, [form.accountType, form.companiesIncluded]);
+
+  const handleChange = <Field extends keyof FormState>(field: Field) =>
+    (value: FormState[Field]) => {
+      setForm((current) => ({
+        ...current,
+        [field]: value,
+      }));
+    };
+
+  const handleInputChange = (field: keyof FormState) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value =
+        field === "companiesIncluded" ? Number(event.target.value) || 0 : event.target.value;
+      handleChange(field)(value as FormState[typeof field]);
+    };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setSubmissionMessage(null);
+
+    const payload = {
+      ...form,
+      totalEstimate,
+    };
+
+    setTimeout(() => {
+      console.log("Mock registration payload", payload);
+      setIsSubmitting(false);
+      setSubmissionMessage("Thanks! A Triumph specialist will reach out to finish your onboarding.");
+      setForm(defaultState);
+    }, 900);
+  };
+
+  return (
+    <section className="form-shell" aria-live="polite">
+      <header>
+        <h2>Create your account</h2>
+        <p>
+          Tell us who is getting started and choose the membership that fits today. We’ll confirm your
+          Triumph mentor and schedule your onboarding session.
+        </p>
+      </header>
+
+      <form className="form-panel form-panel--signup is-active" onSubmit={handleSubmit}>
+        <div className="field-grid">
+          <div className="field">
+            <label htmlFor="register-firstName">First Name</label>
+            <div className="input-shell">
+              <input
+                id="register-firstName"
+                name="firstName"
+                type="text"
+                autoComplete="given-name"
+                placeholder="Jordan"
+                value={form.firstName}
+                onChange={handleInputChange("firstName")}
+                required
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label htmlFor="register-lastName">Last Name</label>
+            <div className="input-shell">
+              <input
+                id="register-lastName"
+                name="lastName"
+                type="text"
+                autoComplete="family-name"
+                placeholder="Rivera"
+                value={form.lastName}
+                onChange={handleInputChange("lastName")}
+                required
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="field">
+          <label htmlFor="register-companyName">Primary Company Name</label>
+          <div className="input-shell">
+            <input
+              id="register-companyName"
+              name="companyName"
+              type="text"
+              autoComplete="organization"
+              placeholder="Triumph Ventures"
+              value={form.companyName}
+              onChange={handleInputChange("companyName")}
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="field">
+          <label htmlFor="register-email">Work Email</label>
+          <div className="input-shell">
+            <input
+              id="register-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@triumph.com"
+              value={form.email}
+              onChange={handleInputChange("email")}
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <div className="field">
+          <label htmlFor="register-password">Create Password</label>
+          <div className="input-shell">
+            <input
+              id="register-password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              placeholder="Minimum 8 characters"
+              value={form.password}
+              onChange={handleInputChange("password")}
+              required
+              minLength={8}
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+
+        <fieldset className="field fieldset">
+          <legend>Select your account type</legend>
+          <div className="plan-grid">
+            {accountOptions.map((option) => {
+              const isActive = form.accountType === option.id;
+              return (
+                <label
+                  key={option.id}
+                  className={`plan-card ${isActive ? "is-selected" : ""}`}
+                  htmlFor={`plan-${option.id}`}
+                >
+                  <input
+                    id={`plan-${option.id}`}
+                    type="radio"
+                    name="accountType"
+                    value={option.id}
+                    checked={isActive}
+                    onChange={() => handleChange("accountType")(option.id)}
+                    disabled={isSubmitting}
+                  />
+                  <span className="plan-card__label">{option.label}</span>
+                  <span className="plan-card__price">{option.price}</span>
+                  <span className="plan-card__description">{option.description}</span>
+                  <span className="plan-card__details">{option.details}</span>
+                </label>
+              );
+            })}
+          </div>
+          {form.accountType === "multi" ? (
+            <div className="field plan-addon">
+              <label htmlFor="register-companiesIncluded">How many companies do you manage?</label>
+              <div className="input-shell">
+                <input
+                  id="register-companiesIncluded"
+                  name="companiesIncluded"
+                  type="number"
+                  min={1}
+                  value={form.companiesIncluded}
+                  onChange={handleInputChange("companiesIncluded")}
+                  disabled={isSubmitting}
+                />
+              </div>
+              <p className="help-text">
+                {form.companiesIncluded <= 3
+                  ? "Your first three companies are included in the monthly rate."
+                  : `Estimated monthly total: $${totalEstimate.toLocaleString()}.`}
+              </p>
+            </div>
+          ) : (
+            <p className="help-text">
+              Manage one business today and upgrade any time as your portfolio grows.
+            </p>
+          )}
+        </fieldset>
+
+        <div className="plan-summary">
+          <p>
+            <strong>Estimated monthly investment:</strong> ${totalEstimate.toLocaleString()} USD
+          </p>
+          {form.accountType === "multi" && form.companiesIncluded > 3 ? (
+            <p>
+              Includes ${Math.min(form.companiesIncluded, 3)} companies in the base plan plus {" "}
+              {form.companiesIncluded - 3} additional at $39 each.
+            </p>
+          ) : (
+            <p>Includes Triumph mentor onboarding and full access for your core team.</p>
+          )}
+        </div>
+
+        <button type="submit" className="primary-button" disabled={isSubmitting}>
+          {isSubmitting ? "Submitting" : "Create Account"}
+        </button>
+
+        {submissionMessage ? <p className="success-message">{submissionMessage}</p> : null}
+      </form>
+    </section>
+  );
+}

--- a/app/register/RegisterHero.tsx
+++ b/app/register/RegisterHero.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import Image from "next/image";
+
+import RegisterForm from "./RegisterForm";
+
+const heroImageSrc =
+  "https://drive.google.com/uc?export=view&id=1QBmt10l53-TTZIrYMz2DWE5d6ZzgpGhy";
+const logoSrc =
+  "https://jkdxxystdtqfbqlmyzrt.supabase.co/storage/v1/object/public/Brand-Assets/TBS%20Logo%20-%20Horizontal%20(2).png";
+
+export default function RegisterHero() {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const card = cardRef.current;
+    if (!card) {
+      return;
+    }
+
+    let animationFrame: number | null = null;
+
+    const setCardStyles = (xDeg: number, yDeg: number, glowX: number, glowY: number) => {
+      card.style.setProperty("--tiltX", `${xDeg}deg`);
+      card.style.setProperty("--tiltY", `${yDeg}deg`);
+      card.style.setProperty("--glowX", `${glowX}%`);
+      card.style.setProperty("--glowY", `${glowY}%`);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!card) {
+        return;
+      }
+
+      const rect = card.getBoundingClientRect();
+      const relativeX = (event.clientX - rect.left) / rect.width;
+      const relativeY = (event.clientY - rect.top) / rect.height;
+      const rotateY = (relativeX - 0.5) * 16;
+      const rotateX = (0.5 - relativeY) * 12;
+      const glowX = 50 + (relativeX - 0.5) * 60;
+      const glowY = 50 + (relativeY - 0.5) * 60;
+
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+
+      animationFrame = requestAnimationFrame(() => {
+        setCardStyles(rotateX, rotateY, glowX, glowY);
+      });
+    };
+
+    const resetCard = () => {
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+
+      setCardStyles(0, 0, 50, 50);
+    };
+
+    card.addEventListener("pointermove", handlePointerMove);
+    card.addEventListener("pointerleave", resetCard);
+    card.addEventListener("pointerup", resetCard);
+
+    return () => {
+      card.removeEventListener("pointermove", handlePointerMove);
+      card.removeEventListener("pointerleave", resetCard);
+      card.removeEventListener("pointerup", resetCard);
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, []);
+
+  return (
+    <main className="login-frame">
+      <div className="login-card" ref={cardRef}>
+        <section className="card-info">
+          <div className="info-logo">
+            <span>
+              <Image
+                src={logoSrc}
+                alt="Triumph Business Solutions logo"
+                width={320}
+                height={120}
+                priority
+                unoptimized
+                className="info-logo__image"
+              />
+            </span>
+          </div>
+          <p className="info-kicker">Triumph Business Solutions</p>
+          <h1>Launch your Business Revenue Model workspace</h1>
+          <p>
+            Choose the plan that fits your journey today and grow without friction tomorrow. Every
+            account includes Triumph mentor onboarding and the playbooks you need to move with
+            confidence.
+          </p>
+          <ul>
+            <li>
+              <span className="icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" focusable="false">
+                  <path d="M7.6 13.2 4.8 10.4l1.4-1.4 1.4 1.4 4.3-4.3 1.4 1.4Z" fill="currentColor" />
+                </svg>
+              </span>
+              Guided activation call with a Triumph mentor
+            </li>
+            <li>
+              <span className="icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" focusable="false">
+                  <path d="m8.2 14.2-3.4-3.4 1.4-1.4 2 2L13.6 6l1.4 1.4Z" fill="currentColor" />
+                </svg>
+              </span>
+              Access to the revenue roadmap, templates, and reporting suite
+            </li>
+            <li>
+              <span className="icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" focusable="false">
+                  <path d="m8.3 14.4-3.5-3.5 1.4-1.4 2.1 2.1 4.5-4.5 1.4 1.4Z" fill="currentColor" />
+                </svg>
+              </span>
+              Flexible seats for mentors and team collaborators
+            </li>
+          </ul>
+        </section>
+
+        <div className="card-form">
+          <RegisterForm />
+        </div>
+
+        <div className="card-illustration" aria-hidden="true">
+          <span>
+            <Image
+              src={heroImageSrc}
+              alt="Triumph Business Solutions safari illustration"
+              width={340}
+              height={340}
+              priority
+              unoptimized
+            />
+          </span>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+import "../login/login.css";
+import RegisterHero from "./RegisterHero";
+
+export const metadata: Metadata = {
+  title: "Create your account | Business Revenue Model App",
+};
+
+export default function RegisterPage() {
+  return (
+    <div className="login-scene">
+      <div className="login-particles" aria-hidden="true" />
+      <RegisterHero />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated /register route that mirrors the login experience while highlighting Triumph onboarding benefits
- add a guided registration form with account details, plan selection, and dynamic pricing estimates for single and multi-company tiers
- extend shared styling to support plan cards, pricing summaries, and success states for the onboarding flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7541d79a0832cbf82292d8e0bf2e1